### PR TITLE
fix(README): use gh-pages image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DTL (Dungeon Template Library)
 
-![](https://github.com/Kasugaccho/DungeonPicture/blob/master/Picture/Logo/logo_color640_2.gif)
+![](https://Kasugaccho.github.io/DungeonPicture/Picture/Logo/logo_color640_2.gif)
 
 ![BSL-1.0](https://img.shields.io/badge/license-BSL--1.0-blue.svg)
 


### PR DESCRIPTION
こんどこそ治ったはず。

cache破棄のために

```
$curl -X PURGE https://camo.githubusercontent.com/4ffb7706356d09832a3c28e5bf1805d6552f603e/68747470733a2f2f4b61737567616363686f2e6769746875622e696f2f44756e67656f6e506963747572652f506963747572652f4c6f676f2f6c6f676f5f636f6c6f723634305f322e676966
{"status": "ok", "id": "19947-1553285183-3381755"}
```

するのはいいとして、結局その後Github上でcommitするとcacheが再更新されないっぽい・・・？