### PR TITLE
コードの重複を削減するため、CRTP を使用するように変更しました。

### DIFF
--- a/include/Shape/AbsoluteRect.hpp
+++ b/include/Shape/AbsoluteRect.hpp
@@ -25,29 +25,21 @@
 #include <Base/Struct.hpp>
 #include <Macros/nodiscard.hpp>
 #include <Macros/constexpr.hpp>
+#include <Utility/RectBaseWithValue.hpp>
 
 namespace dtl {
 	inline namespace shape {
 
 		//マスを指定した数値で埋める
 		template<typename Matrix_Int_>
-		class AbsoluteRect {
+		class AbsoluteRect : public RectBaseWithValue<AbsoluteRect<Matrix_Int_>, Matrix_Int_> {
 		private:
 
 
 			///// エイリアス /////
 
 			using Index_Size = std::size_t;
-			
-
-
-			///// メンバ変数 /////
-
-			Index_Size start_x{};
-			Index_Size start_y{};
-			Index_Size width{};
-			Index_Size height{};
-			Matrix_Int_ draw_value{};
+			using ShapeBase_t = RectBaseWithValue<AbsoluteRect<Matrix_Int_>, Matrix_Int_>;
 
 
 			///// 代入処理 /////
@@ -120,80 +112,56 @@ namespace dtl {
 		public:
 
 
-			///// 情報取得 /////
-
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getPointX() const noexcept {
-				return this->start_x;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getPointY() const noexcept {
-				return this->start_y;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getWidth() const noexcept {
-				return this->width;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getHeight() const noexcept {
-				return this->height;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Matrix_Int_ getValue() const noexcept {
-				return this->draw_value;
-			}
-
-
 			///// 生成呼び出し /////
 
 			//STL
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_&& matrix_) const noexcept {
-				return this->drawNormal(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= ((matrix_.size() == 0) ? 0 : matrix_[0].size())) ? ((matrix_.size() == 0) ? 0 : matrix_[0].size()) : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height);
+				return this->drawNormal(std::forward<Matrix_>(matrix_), this->calcEndX((matrix_.size() == 0) ? 0 : matrix_[0].size()), this->calcEndY(matrix_.size()));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_&& matrix_, Function_&& function_) const noexcept {
-				return this->drawNormal(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= ((matrix_.size() == 0) ? 0 : matrix_[0].size())) ? ((matrix_.size() == 0) ? 0 : matrix_[0].size()) : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height, function_);
+				return this->drawNormal(std::forward<Matrix_>(matrix_), this->calcEndX((matrix_.size() == 0) ? 0 : matrix_[0].size()), this->calcEndY(matrix_.size()), function_);
 			}
 
 			//LayerSTL
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ && matrix_, const Index_Size layer_) const noexcept {
-				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, (this->width == 0 || this->start_x + this->width >= ((matrix_.size() == 0) ? 0 : matrix_[0].size())) ? ((matrix_.size() == 0) ? 0 : matrix_[0].size()) : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height);
+				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, this->calcEndX((matrix_.size() == 0) ? 0 : matrix_[0].size()), this->calcEndY(matrix_.size()));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size layer_, Function_ && function_) const noexcept {
-				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, (this->width == 0 || this->start_x + this->width >= ((matrix_.size() == 0) ? 0 : matrix_[0].size())) ? ((matrix_.size() == 0) ? 0 : matrix_[0].size()) : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height, function_);
+				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, this->calcEndX((matrix_.size() == 0) ? 0 : matrix_[0].size()), this->calcEndY(matrix_.size()), function_);
 			}
 
 			//Normal
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawNormal(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height);
+				return this->drawNormal(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawNormal(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, function_);
+				return this->drawNormal(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), function_);
 			}
 
 			//LayerNormal
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ && matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height);
+				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, this->calcEndX(max_x_), this->calcEndY(max_y_));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, function_);
+				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, this->calcEndX(max_x_), this->calcEndY(max_y_), function_);
 			}
 
 			//Array
 			template<typename Matrix_>
 			constexpr bool drawArray(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawArray(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, max_x_);
+				return this->drawArray(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), max_x_);
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperatorArray(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawArray(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, max_x_, function_);
+				return this->drawArray(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), max_x_, function_);
 			}
 
 
@@ -233,148 +201,9 @@ namespace dtl {
 			}
 
 
-			///// 消去 /////
-
-			//始点座標Xを初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				AbsoluteRect& clearPointX() noexcept {
-				this->start_x = 0;
-				return *this;
-			}
-			//始点座標Yを初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				AbsoluteRect& clearPointY() noexcept {
-				this->start_y = 0;
-				return *this;
-			}
-			//範囲の大きさ(X軸方向)を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				AbsoluteRect& clearWidth() noexcept {
-				this->width = 0;
-				return *this;
-			}
-			//範囲の大きさ(Y軸方向)を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				AbsoluteRect& clearHeight() noexcept {
-				this->height = 0;
-				return *this;
-			}
-			//塗り値を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				AbsoluteRect& clearValue() noexcept {
-				const Matrix_Int_ new_draw_value{};
-				this->draw_value = new_draw_value;
-				return *this;
-			}
-			//始点座標(X,Y)を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				AbsoluteRect& clearPoint() noexcept {
-				this->clearPointX();
-				this->clearPointY();
-				return *this;
-			}
-			//描画範囲を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				AbsoluteRect& clearRange() noexcept {
-				this->clearPointX();
-				this->clearPointY();
-				this->clearWidth();
-				this->clearHeight();
-				return *this;
-			}
-			//全ての値を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				AbsoluteRect& clear() noexcept {
-				this->clearRange();
-				this->clearValue();
-				return *this;
-			}
-
-
-			///// 代入 /////
-
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				AbsoluteRect& setPointX(const Index_Size end_x_) noexcept {
-				this->start_x = end_x_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				AbsoluteRect& setPointY(const Index_Size end_y_) noexcept {
-				this->start_y = end_y_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				AbsoluteRect& setWidth(const Index_Size width_) noexcept {
-				this->width = width_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				AbsoluteRect& setHeight(const Index_Size height_) noexcept {
-				this->height = height_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				AbsoluteRect& setValue(const Matrix_Int_ & draw_value_) noexcept {
-				this->draw_value = draw_value_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				AbsoluteRect& setPoint(const Index_Size point_) noexcept {
-				this->start_x = point_;
-				this->start_y = point_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				AbsoluteRect& setPoint(const Index_Size end_x_, const Index_Size end_y_) noexcept {
-				this->start_x = end_x_;
-				this->start_y = end_y_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				AbsoluteRect& setRange(const Index_Size end_x_, const Index_Size end_y_, const Index_Size length_) noexcept {
-				this->start_x = end_x_;
-				this->start_y = end_y_;
-				this->width = length_;
-				this->height = length_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				AbsoluteRect& setRange(const Index_Size end_x_, const Index_Size end_y_, const Index_Size width_, const Index_Size height_) noexcept {
-				this->start_x = end_x_;
-				this->start_y = end_y_;
-				this->width = width_;
-				this->height = height_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				AbsoluteRect& setRange(const dtl::base::MatrixRange & matrix_range_) noexcept {
-				this->start_x = matrix_range_.x;
-				this->start_y = matrix_range_.y;
-				this->width = matrix_range_.w;
-				this->height = matrix_range_.h;
-				return *this;
-			}
-
-
 			///// コンストラクタ /////
 
-			constexpr AbsoluteRect() noexcept = default;
-			constexpr explicit AbsoluteRect(const Matrix_Int_ & draw_value_) noexcept
-				:draw_value(draw_value_) {}
-			constexpr explicit AbsoluteRect(const dtl::base::MatrixRange & matrix_range_) noexcept
-				:start_x(matrix_range_.x), start_y(matrix_range_.y),
-				width(matrix_range_.w), height(matrix_range_.h) {}
-			constexpr explicit AbsoluteRect(const dtl::base::MatrixRange & matrix_range_, const Matrix_Int_ & draw_value_) noexcept
-				:start_x(matrix_range_.x), start_y(matrix_range_.y),
-				width(matrix_range_.w), height(matrix_range_.h),
-				draw_value(draw_value_) {}
-			constexpr explicit AbsoluteRect(const Index_Size end_x_, const Index_Size end_y_, const Index_Size width_, const Index_Size height_) noexcept
-				:start_x(end_x_), start_y(end_y_),
-				width(width_), height(height_) {}
-			constexpr explicit AbsoluteRect(const Index_Size end_x_, const Index_Size end_y_, const Index_Size width_, const Index_Size height_, const Matrix_Int_ & draw_value_) noexcept
-				:start_x(end_x_), start_y(end_y_),
-				width(width_), height(height_),
-				draw_value(draw_value_) {}
+			using ShapeBase_t::ShapeBase_t;
 		};
 	}
 }

--- a/include/Shape/Border.hpp
+++ b/include/Shape/Border.hpp
@@ -25,29 +25,21 @@
 #include <Base/Struct.hpp>
 #include <Macros/nodiscard.hpp>
 #include <Macros/constexpr.hpp>
+#include <Utility/RectBaseWithValue.hpp>
 
 namespace dtl {
 	inline namespace shape {
 
 		//マップの外枠を指定した数値で埋める
 		template<typename Matrix_Int_>
-		class Border {
+		class Border : public RectBaseWithValue<Border<Matrix_Int_>, Matrix_Int_> {
 		private:
 
 
 			///// エイリアス /////
 
 			using Index_Size = std::size_t;
-			
-
-
-			///// メンバ変数 /////
-
-			Index_Size start_x{};
-			Index_Size start_y{};
-			Index_Size width{};
-			Index_Size height{};
-			Matrix_Int_ draw_value{};
+			using ShapeBase_t = RectBaseWithValue<Border<Matrix_Int_>, Matrix_Int_>;
 
 
 			///// 代入処理 /////
@@ -206,80 +198,56 @@ namespace dtl {
 		public:
 
 
-			///// 情報取得 /////
-
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getPointX() const noexcept {
-				return this->start_x;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getPointY() const noexcept {
-				return this->start_y;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getWidth() const noexcept {
-				return this->width;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getHeight() const noexcept {
-				return this->height;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Matrix_Int_ getValue() const noexcept {
-				return this->draw_value;
-			}
-
-
 			///// 生成呼び出し /////
 
 			//STL
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ && matrix_) const noexcept {
-				return (this->width == 0) ? this->drawSTL(std::forward<Matrix_>(matrix_), (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height) : this->drawWidthSTL(matrix_, this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height);
+				return (this->width == 0) ? this->drawSTL(std::forward<Matrix_>(matrix_), this->calcEndY(matrix_.size())) : this->drawWidthSTL(matrix_, this->start_x + this->width, this->calcEndY(matrix_.size()));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ && matrix_, Function_ && function_) const noexcept {
-				return (this->width == 0) ? this->drawSTL(std::forward<Matrix_>(matrix_), (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height, function_) : this->drawWidthSTL(matrix_, this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height, function_);
+				return (this->width == 0) ? this->drawSTL(std::forward<Matrix_>(matrix_), this->calcEndY(matrix_.size()), function_) : this->drawWidthSTL(matrix_, this->start_x + this->width, this->calcEndY(matrix_.size()), function_);
 			}
 
 			//LayerSTL
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ && matrix_, const Index_Size layer_) const noexcept {
-				return (this->width == 0) ? this->drawLayerSTL(std::forward<Matrix_>(matrix_), layer_, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height);
+				return (this->width == 0) ? this->drawLayerSTL(std::forward<Matrix_>(matrix_), layer_, this->calcEndY(matrix_.size())) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, this->calcEndY(matrix_.size()));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size layer_, Function_ && function_) const noexcept {
-				return (this->width == 0) ? this->drawLayerSTL(std::forward<Matrix_>(matrix_), layer_, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height, function_) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height, function_);
+				return (this->width == 0) ? this->drawLayerSTL(std::forward<Matrix_>(matrix_), layer_, this->calcEndY(matrix_.size()), function_) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, this->calcEndY(matrix_.size()), function_);
 			}
 
 			//Normal
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawNormal(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height);
+				return this->drawNormal(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawNormal(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, function_);
+				return this->drawNormal(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), function_);
 			}
 
 			//LayerNormal
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ && matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height);
+				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, this->calcEndX(max_x_), this->calcEndY(max_y_));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, function_);
+				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, this->calcEndX(max_x_), this->calcEndY(max_y_), function_);
 			}
 
 			//Array
 			template<typename Matrix_>
 			constexpr bool drawArray(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawArray(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, max_x_);
+				return this->drawArray(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), max_x_);
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperatorArray(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawArray(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, max_x_, function_);
+				return this->drawArray(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), max_x_, function_);
 			}
 
 
@@ -319,148 +287,9 @@ namespace dtl {
 			}
 
 
-			///// 消去 /////
-
-			//始点座標Xを初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Border& clearPointX() noexcept {
-				this->start_x = 0;
-				return *this;
-			}
-			//始点座標Yを初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Border& clearPointY() noexcept {
-				this->start_y = 0;
-				return *this;
-			}
-			//範囲の大きさ(X軸方向)を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Border& clearWidth() noexcept {
-				this->width = 0;
-				return *this;
-			}
-			//範囲の大きさ(Y軸方向)を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Border& clearHeight() noexcept {
-				this->height = 0;
-				return *this;
-			}
-			//塗り値を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Border& clearValue() noexcept {
-				const Matrix_Int_ new_draw_value{};
-				this->draw_value = new_draw_value;
-				return *this;
-			}
-			//始点座標(X,Y)を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Border& clearPoint() noexcept {
-				this->clearPointX();
-				this->clearPointY();
-				return *this;
-			}
-			//描画範囲を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Border& clearRange() noexcept {
-				this->clearPointX();
-				this->clearPointY();
-				this->clearWidth();
-				this->clearHeight();
-				return *this;
-			}
-			//全ての値を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Border& clear() noexcept {
-				this->clearRange();
-				this->clearValue();
-				return *this;
-			}
-
-
-			///// 代入 /////
-
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Border& setPointX(const Index_Size end_x_) noexcept {
-				this->start_x = end_x_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Border& setPointY(const Index_Size end_y_) noexcept {
-				this->start_y = end_y_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Border& setWidth(const Index_Size width_) noexcept {
-				this->width = width_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Border& setHeight(const Index_Size height_) noexcept {
-				this->height = height_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Border& setValue(const Matrix_Int_ & draw_value_) noexcept {
-				this->draw_value = draw_value_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Border& setPoint(const Index_Size point_) noexcept {
-				this->start_x = point_;
-				this->start_y = point_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Border& setPoint(const Index_Size end_x_, const Index_Size end_y_) noexcept {
-				this->start_x = end_x_;
-				this->start_y = end_y_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Border& setRange(const Index_Size end_x_, const Index_Size end_y_, const Index_Size length_) noexcept {
-				this->start_x = end_x_;
-				this->start_y = end_y_;
-				this->width = length_;
-				this->height = length_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Border& setRange(const Index_Size end_x_, const Index_Size end_y_, const Index_Size width_, const Index_Size height_) noexcept {
-				this->start_x = end_x_;
-				this->start_y = end_y_;
-				this->width = width_;
-				this->height = height_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Border& setRange(const dtl::base::MatrixRange & matrix_range_) noexcept {
-				this->start_x = matrix_range_.x;
-				this->start_y = matrix_range_.y;
-				this->width = matrix_range_.w;
-				this->height = matrix_range_.h;
-				return *this;
-			}
-
-
 			///// コンストラクタ /////
 
-			constexpr Border() noexcept = default;
-			constexpr explicit Border(const Matrix_Int_ & draw_value_) noexcept
-				:draw_value(draw_value_) {}
-			constexpr explicit Border(const dtl::base::MatrixRange & matrix_range_) noexcept
-				:start_x(matrix_range_.x), start_y(matrix_range_.y),
-				width(matrix_range_.w), height(matrix_range_.h) {}
-			constexpr explicit Border(const dtl::base::MatrixRange & matrix_range_, const Matrix_Int_ & draw_value_) noexcept
-				:start_x(matrix_range_.x), start_y(matrix_range_.y),
-				width(matrix_range_.w), height(matrix_range_.h),
-				draw_value(draw_value_) {}
-			constexpr explicit Border(const Index_Size end_x_, const Index_Size end_y_, const Index_Size width_, const Index_Size height_) noexcept
-				:start_x(end_x_), start_y(end_y_),
-				width(width_), height(height_) {}
-			constexpr explicit Border(const Index_Size end_x_, const Index_Size end_y_, const Index_Size width_, const Index_Size height_, const Matrix_Int_ & draw_value_) noexcept
-				:start_x(end_x_), start_y(end_y_),
-				width(width_), height(height_),
-				draw_value(draw_value_) {}
+			using ShapeBase_t::ShapeBase_t;
 		};
 	}
 }

--- a/include/Shape/BorderOdd.hpp
+++ b/include/Shape/BorderOdd.hpp
@@ -25,29 +25,21 @@
 #include <Base/Struct.hpp>
 #include <Macros/nodiscard.hpp>
 #include <Macros/constexpr.hpp>
+#include <Utility/RectBaseWithValue.hpp>
 
 namespace dtl {
 	inline namespace shape {
 
 		//四角形の生成
 		template<typename Matrix_Int_>
-		class BorderOdd {
+		class BorderOdd : public RectBaseWithValue<BorderOdd<Matrix_Int_>, Matrix_Int_> {
 		private:
 
 
 			///// エイリアス /////
 
 			using Index_Size = std::size_t;
-			
-
-
-			///// メンバ変数 /////
-
-			Index_Size start_x{};
-			Index_Size start_y{};
-			Index_Size width{};
-			Index_Size height{};
-			Matrix_Int_ draw_value{};
+			using ShapeBase_t = RectBaseWithValue<BorderOdd<Matrix_Int_>, Matrix_Int_>;
 
 
 			///// 代入処理 /////
@@ -234,80 +226,56 @@ namespace dtl {
 		public:
 
 
-			///// 情報取得 /////
-
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getPointX() const noexcept {
-				return this->start_x;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getPointY() const noexcept {
-				return this->start_y;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getWidth() const noexcept {
-				return this->width;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getHeight() const noexcept {
-				return this->height;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Matrix_Int_ getValue() const noexcept {
-				return this->draw_value;
-			}
-
-
 			///// 生成呼び出し /////
 
 			//STL
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ && matrix_) const noexcept {
-				return (this->width == 0) ? this->drawSTL(std::forward<Matrix_>(matrix_), (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height) : this->drawWidthSTL(matrix_, this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height);
+				return (this->width == 0) ? this->drawSTL(std::forward<Matrix_>(matrix_), this->calcEndY(matrix_.size())) : this->drawWidthSTL(matrix_, this->start_x + this->width, this->calcEndY(matrix_.size()));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ && matrix_, Function_ && function_) const noexcept {
-				return (this->width == 0) ? this->drawSTL(std::forward<Matrix_>(matrix_), (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height, function_) : this->drawWidthSTL(matrix_, this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height, function_);
+				return (this->width == 0) ? this->drawSTL(std::forward<Matrix_>(matrix_), this->calcEndY(matrix_.size()), function_) : this->drawWidthSTL(matrix_, this->start_x + this->width, this->calcEndY(matrix_.size()), function_);
 			}
 
 			//LayerSTL
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ && matrix_, const Index_Size layer_) const noexcept {
-				return (this->width == 0) ? this->drawLayerSTL(std::forward<Matrix_>(matrix_), layer_, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height);
+				return (this->width == 0) ? this->drawLayerSTL(std::forward<Matrix_>(matrix_), layer_, this->calcEndY(matrix_.size())) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, this->calcEndY(matrix_.size()));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size layer_, Function_ && function_) const noexcept {
-				return (this->width == 0) ? this->drawLayerSTL(std::forward<Matrix_>(matrix_), layer_, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height, function_) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height, function_);
+				return (this->width == 0) ? this->drawLayerSTL(std::forward<Matrix_>(matrix_), layer_, this->calcEndY(matrix_.size()), function_) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, this->calcEndY(matrix_.size()), function_);
 			}
 
 			//Normal
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawNormal(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height);
+				return this->drawNormal(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawNormal(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, function_);
+				return this->drawNormal(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), function_);
 			}
 
 			//LayerNormal
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ && matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height);
+				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, this->calcEndX(max_x_), this->calcEndY(max_y_));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, function_);
+				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, this->calcEndX(max_x_), this->calcEndY(max_y_), function_);
 			}
 
 			//Array
 			template<typename Matrix_>
 			constexpr bool drawArray(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawArray(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, max_x_);
+				return this->drawArray(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), max_x_);
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperatorArray(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawArray(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, max_x_, function_);
+				return this->drawArray(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), max_x_, function_);
 			}
 
 
@@ -347,148 +315,9 @@ namespace dtl {
 			}
 
 
-			///// 消去 /////
-
-			//始点座標Xを初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				BorderOdd& clearPointX() noexcept {
-				this->start_x = 0;
-				return *this;
-			}
-			//始点座標Yを初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				BorderOdd& clearPointY() noexcept {
-				this->start_y = 0;
-				return *this;
-			}
-			//範囲の大きさ(X軸方向)を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				BorderOdd& clearWidth() noexcept {
-				this->width = 0;
-				return *this;
-			}
-			//範囲の大きさ(Y軸方向)を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				BorderOdd& clearHeight() noexcept {
-				this->height = 0;
-				return *this;
-			}
-			//塗り値を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				BorderOdd& clearValue() noexcept {
-				const Matrix_Int_ new_draw_value{};
-				this->draw_value = new_draw_value;
-				return *this;
-			}
-			//始点座標(X,Y)を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				BorderOdd& clearPoint() noexcept {
-				this->clearPointX();
-				this->clearPointY();
-				return *this;
-			}
-			//描画範囲を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				BorderOdd& clearRange() noexcept {
-				this->clearPointX();
-				this->clearPointY();
-				this->clearWidth();
-				this->clearHeight();
-				return *this;
-			}
-			//全ての値を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				BorderOdd& clear() noexcept {
-				this->clearRange();
-				this->clearValue();
-				return *this;
-			}
-
-
-			///// 代入 /////
-
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				BorderOdd& setPointX(const Index_Size end_x_) noexcept {
-				this->start_x = end_x_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				BorderOdd& setPointY(const Index_Size end_y_) noexcept {
-				this->start_y = end_y_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				BorderOdd& setWidth(const Index_Size width_) noexcept {
-				this->width = width_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				BorderOdd& setHeight(const Index_Size height_) noexcept {
-				this->height = height_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				BorderOdd& setValue(const Matrix_Int_& draw_value_) noexcept {
-				this->draw_value = draw_value_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				BorderOdd& setPoint(const Index_Size point_) noexcept {
-				this->start_x = point_;
-				this->start_y = point_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				BorderOdd& setPoint(const Index_Size end_x_, const Index_Size end_y_) noexcept {
-				this->start_x = end_x_;
-				this->start_y = end_y_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				BorderOdd& setRange(const Index_Size end_x_, const Index_Size end_y_, const Index_Size length_) noexcept {
-				this->start_x = end_x_;
-				this->start_y = end_y_;
-				this->width = length_;
-				this->height = length_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				BorderOdd& setRange(const Index_Size end_x_, const Index_Size end_y_, const Index_Size width_, const Index_Size height_) noexcept {
-				this->start_x = end_x_;
-				this->start_y = end_y_;
-				this->width = width_;
-				this->height = height_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				BorderOdd& setRange(const dtl::base::MatrixRange& matrix_range_) noexcept {
-				this->start_x = matrix_range_.x;
-				this->start_y = matrix_range_.y;
-				this->width = matrix_range_.w;
-				this->height = matrix_range_.h;
-				return *this;
-			}
-
-
 			///// コンストラクタ /////
 
-			constexpr BorderOdd() noexcept = default;
-			constexpr explicit BorderOdd(const Matrix_Int_ & draw_value_) noexcept
-				:draw_value(draw_value_) {}
-			constexpr explicit BorderOdd(const dtl::base::MatrixRange & matrix_range_) noexcept
-				:start_x(matrix_range_.x), start_y(matrix_range_.y),
-				width(matrix_range_.w), height(matrix_range_.h) {}
-			constexpr explicit BorderOdd(const dtl::base::MatrixRange & matrix_range_, const Matrix_Int_ & draw_value_) noexcept
-				:start_x(matrix_range_.x), start_y(matrix_range_.y),
-				width(matrix_range_.w), height(matrix_range_.h),
-				draw_value(draw_value_) {}
-			constexpr explicit BorderOdd(const Index_Size end_x_, const Index_Size end_y_, const Index_Size width_, const Index_Size height_) noexcept
-				:start_x(end_x_), start_y(end_y_),
-				width(width_), height(height_) {}
-			constexpr explicit BorderOdd(const Index_Size end_x_, const Index_Size end_y_, const Index_Size width_, const Index_Size height_, const Matrix_Int_ & draw_value_) noexcept
-				:start_x(end_x_), start_y(end_y_),
-				width(width_), height(height_),
-				draw_value(draw_value_) {}
+			using ShapeBase_t::ShapeBase_t;
 		};
 	}
 }

--- a/include/Shape/PointGrid.hpp
+++ b/include/Shape/PointGrid.hpp
@@ -25,29 +25,21 @@
 #include <Base/Struct.hpp>
 #include <Macros/nodiscard.hpp>
 #include <Macros/constexpr.hpp>
+#include <Utility/RectBaseWithValue.hpp>
 
 namespace dtl {
 	inline namespace shape {
 
 		//偶数マスを指定した数値で埋める
 		template<typename Matrix_Int_>
-		class PointGrid {
+		class PointGrid : public RectBaseWithValue<PointGrid<Matrix_Int_>, Matrix_Int_> {
 		private:
 
 
 			///// エイリアス /////
 
 			using Index_Size = std::size_t;
-			
-
-
-			///// メンバ変数 /////
-
-			Index_Size start_x{};
-			Index_Size start_y{};
-			Index_Size width{};
-			Index_Size height{};
-			Matrix_Int_ draw_value{};
+			using ShapeBase_t = RectBaseWithValue<PointGrid<Matrix_Int_>, Matrix_Int_>;
 
 
 			///// 代入処理 /////
@@ -156,80 +148,56 @@ namespace dtl {
 		public:
 
 
-			///// 情報取得 /////
-
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getPointX() const noexcept {
-				return this->start_x;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getPointY() const noexcept {
-				return this->start_y;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getWidth() const noexcept {
-				return this->width;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getHeight() const noexcept {
-				return this->height;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Matrix_Int_ getValue() const noexcept {
-				return this->draw_value;
-			}
-
-
 			///// 生成呼び出し /////
 
 			//STL
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ && matrix_) const noexcept {
-				return (this->width == 0) ? this->drawSTL(std::forward<Matrix_>(matrix_), (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height) : this->drawWidthSTL(matrix_, this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height);
+				return (this->width == 0) ? this->drawSTL(std::forward<Matrix_>(matrix_), this->calcEndY(matrix_.size())) : this->drawWidthSTL(matrix_, this->start_x + this->width, this->calcEndY(matrix_.size()));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ && matrix_, Function_ && function_) const noexcept {
-				return (this->width == 0) ? this->drawSTL(std::forward<Matrix_>(matrix_), (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height, function_) : this->drawWidthSTL(matrix_, this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height, function_);
+				return (this->width == 0) ? this->drawSTL(std::forward<Matrix_>(matrix_), this->calcEndY(matrix_.size()), function_) : this->drawWidthSTL(matrix_, this->start_x + this->width, this->calcEndY(matrix_.size()), function_);
 			}
 
 			//LayerSTL
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ && matrix_, const Index_Size layer_) const noexcept {
-				return (this->width == 0) ? this->drawLayerSTL(std::forward<Matrix_>(matrix_), layer_, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height);
+				return (this->width == 0) ? this->drawLayerSTL(std::forward<Matrix_>(matrix_), layer_, this->calcEndY(matrix_.size())) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, this->calcEndY(matrix_.size()));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size layer_, Function_ && function_) const noexcept {
-				return (this->width == 0) ? this->drawLayerSTL(std::forward<Matrix_>(matrix_), layer_, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height, function_) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height, function_);
+				return (this->width == 0) ? this->drawLayerSTL(std::forward<Matrix_>(matrix_), layer_, this->calcEndY(matrix_.size()), function_) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, this->calcEndY(matrix_.size()), function_);
 			}
 
 			//Normal
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawNormal(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height);
+				return this->drawNormal(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawNormal(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, function_);
+				return this->drawNormal(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), function_);
 			}
 
 			//LayerNormal
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ && matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height);
+				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, this->calcEndX(max_x_), this->calcEndY(max_y_));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, function_);
+				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, this->calcEndX(max_x_), this->calcEndY(max_y_), function_);
 			}
 
 			//Array
 			template<typename Matrix_>
 			constexpr bool drawArray(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawArray(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, max_x_);
+				return this->drawArray(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), max_x_);
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperatorArray(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawArray(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, max_x_, function_);
+				return this->drawArray(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), max_x_, function_);
 			}
 
 
@@ -269,148 +237,9 @@ namespace dtl {
 			}
 
 
-			///// 消去 /////
-
-			//始点座標Xを初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				PointGrid& clearPointX() noexcept {
-				this->start_x = 0;
-				return *this;
-			}
-			//始点座標Yを初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				PointGrid& clearPointY() noexcept {
-				this->start_y = 0;
-				return *this;
-			}
-			//範囲の大きさ(X軸方向)を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				PointGrid& clearWidth() noexcept {
-				this->width = 0;
-				return *this;
-			}
-			//範囲の大きさ(Y軸方向)を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				PointGrid& clearHeight() noexcept {
-				this->height = 0;
-				return *this;
-			}
-			//塗り値を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				PointGrid& clearValue() noexcept {
-				const Matrix_Int_ new_draw_value{};
-				this->draw_value = new_draw_value;
-				return *this;
-			}
-			//始点座標(X,Y)を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				PointGrid& clearPoint() noexcept {
-				this->clearPointX();
-				this->clearPointY();
-				return *this;
-			}
-			//描画範囲を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				PointGrid& clearRange() noexcept {
-				this->clearPointX();
-				this->clearPointY();
-				this->clearWidth();
-				this->clearHeight();
-				return *this;
-			}
-			//全ての値を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				PointGrid& clear() noexcept {
-				this->clearRange();
-				this->clearValue();
-				return *this;
-			}
-
-
-			///// 代入 /////
-
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				PointGrid& setPointX(const Index_Size end_x_) noexcept {
-				this->start_x = end_x_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				PointGrid& setPointY(const Index_Size end_y_) noexcept {
-				this->start_y = end_y_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				PointGrid& setWidth(const Index_Size width_) noexcept {
-				this->width = width_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				PointGrid& setHeight(const Index_Size height_) noexcept {
-				this->height = height_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				PointGrid& setValue(const Matrix_Int_& draw_value_) noexcept {
-				this->draw_value = draw_value_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				PointGrid& setPoint(const Index_Size point_) noexcept {
-				this->start_x = point_;
-				this->start_y = point_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				PointGrid& setPoint(const Index_Size end_x_, const Index_Size end_y_) noexcept {
-				this->start_x = end_x_;
-				this->start_y = end_y_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				PointGrid& setRange(const Index_Size end_x_, const Index_Size end_y_, const Index_Size length_) noexcept {
-				this->start_x = end_x_;
-				this->start_y = end_y_;
-				this->width = length_;
-				this->height = length_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				PointGrid& setRange(const Index_Size end_x_, const Index_Size end_y_, const Index_Size width_, const Index_Size height_) noexcept {
-				this->start_x = end_x_;
-				this->start_y = end_y_;
-				this->width = width_;
-				this->height = height_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				PointGrid& setRange(const dtl::base::MatrixRange& matrix_range_) noexcept {
-				this->start_x = matrix_range_.x;
-				this->start_y = matrix_range_.y;
-				this->width = matrix_range_.w;
-				this->height = matrix_range_.h;
-				return *this;
-			}
-
-
 			///// コンストラクタ /////
 
-			constexpr PointGrid() noexcept = default;
-			constexpr explicit PointGrid(const Matrix_Int_ & draw_value_) noexcept
-				:draw_value(draw_value_) {}
-			constexpr explicit PointGrid(const dtl::base::MatrixRange & matrix_range_) noexcept
-				:start_x(matrix_range_.x), start_y(matrix_range_.y),
-				width(matrix_range_.w), height(matrix_range_.h) {}
-			constexpr explicit PointGrid(const dtl::base::MatrixRange & matrix_range_, const Matrix_Int_ & draw_value_) noexcept
-				:start_x(matrix_range_.x), start_y(matrix_range_.y),
-				width(matrix_range_.w), height(matrix_range_.h),
-				draw_value(draw_value_) {}
-			constexpr explicit PointGrid(const Index_Size end_x_, const Index_Size end_y_, const Index_Size width_, const Index_Size height_) noexcept
-				:start_x(end_x_), start_y(end_y_),
-				width(width_), height(height_) {}
-			constexpr explicit PointGrid(const Index_Size end_x_, const Index_Size end_y_, const Index_Size width_, const Index_Size height_, const Matrix_Int_ & draw_value_) noexcept
-				:start_x(end_x_), start_y(end_y_),
-				width(width_), height(height_),
-				draw_value(draw_value_) {}
+			using ShapeBase_t::ShapeBase_t;
 		};
 	}
 }

--- a/include/Shape/Rect.hpp
+++ b/include/Shape/Rect.hpp
@@ -25,29 +25,21 @@
 #include <Base/Struct.hpp>
 #include <Macros/nodiscard.hpp>
 #include <Macros/constexpr.hpp>
+#include <Utility/RectBaseWithValue.hpp>
 
 namespace dtl {
 	inline namespace shape {
 
 		//マスを指定した数値で埋める
 		template<typename Matrix_Int_>
-		class Rect {
+		class Rect : public RectBaseWithValue<Rect<Matrix_Int_>, Matrix_Int_> {
 		private:
 
 
 			///// エイリアス /////
 
 			using Index_Size = std::size_t;
-			
-
-
-			///// メンバ変数 /////
-
-			Index_Size start_x{};
-			Index_Size start_y{};
-			Index_Size width{};
-			Index_Size height{};
-			Matrix_Int_ draw_value{};
+			using ShapeBase_t = RectBaseWithValue<Rect<Matrix_Int_>, Matrix_Int_>;
 
 
 			///// 代入処理 /////
@@ -156,80 +148,56 @@ namespace dtl {
 		public:
 
 
-			///// 情報取得 /////
-
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getPointX() const noexcept {
-				return this->start_x;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getPointY() const noexcept {
-				return this->start_y;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getWidth() const noexcept {
-				return this->width;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Index_Size getHeight() const noexcept {
-				return this->height;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
-			constexpr Matrix_Int_ getValue() const noexcept {
-				return this->draw_value;
-			}
-
-
 			///// 生成呼び出し /////
 
 			//STL
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ && matrix_) const noexcept {
-				return (this->width == 0) ? this->drawSTL(std::forward<Matrix_>(matrix_), (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height) : this->drawWidthSTL(matrix_, this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height);
+				return (this->width == 0) ? this->drawSTL(std::forward<Matrix_>(matrix_), this->calcEndY(matrix_.size())) : this->drawWidthSTL(matrix_, this->start_x + this->width, this->calcEndY(matrix_.size()));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ && matrix_, Function_ && function_) const noexcept {
-				return (this->width == 0) ? this->drawSTL(std::forward<Matrix_>(matrix_), (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height, function_) : this->drawWidthSTL(matrix_, this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height, function_);
+				return (this->width == 0) ? this->drawSTL(std::forward<Matrix_>(matrix_), this->calcEndY(matrix_.size()), function_) : this->drawWidthSTL(matrix_, this->start_x + this->width, this->calcEndY(matrix_.size()), function_);
 			}
 
 			//LayerSTL
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ && matrix_, const Index_Size layer_) const noexcept {
-				return (this->width == 0) ? this->drawLayerSTL(std::forward<Matrix_>(matrix_), layer_, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height);
+				return (this->width == 0) ? this->drawLayerSTL(std::forward<Matrix_>(matrix_), layer_, this->calcEndY(matrix_.size())) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, this->calcEndY(matrix_.size()));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size layer_, Function_ && function_) const noexcept {
-				return (this->width == 0) ? this->drawLayerSTL(std::forward<Matrix_>(matrix_), layer_, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height, function_) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= matrix_.size()) ? matrix_.size() : this->start_y + this->height, function_);
+				return (this->width == 0) ? this->drawLayerSTL(std::forward<Matrix_>(matrix_), layer_, this->calcEndY(matrix_.size()), function_) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, this->calcEndY(matrix_.size()), function_);
 			}
 
 			//Normal
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawNormal(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height);
+				return this->drawNormal(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawNormal(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, function_);
+				return this->drawNormal(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), function_);
 			}
 
 			//LayerNormal
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ && matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height);
+				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, this->calcEndX(max_x_), this->calcEndY(max_y_));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, function_);
+				return this->drawLayerNormal(std::forward<Matrix_>(matrix_), layer_, this->calcEndX(max_x_), this->calcEndY(max_y_), function_);
 			}
 
 			//Array
 			template<typename Matrix_>
 			constexpr bool drawArray(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawArray(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, max_x_);
+				return this->drawArray(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), max_x_);
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperatorArray(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawArray(std::forward<Matrix_>(matrix_), (this->width == 0 || this->start_x + this->width >= max_x_) ? max_x_ : this->start_x + this->width, (this->height == 0 || this->start_y + this->height >= max_y_) ? max_y_ : this->start_y + this->height, max_x_, function_);
+				return this->drawArray(std::forward<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), max_x_, function_);
 			}
 
 
@@ -269,148 +237,9 @@ namespace dtl {
 			}
 
 
-			///// 消去 /////
-
-			//始点座標Xを初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Rect& clearPointX() noexcept {
-				this->start_x = 0;
-				return *this;
-			}
-			//始点座標Yを初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Rect& clearPointY() noexcept {
-				this->start_y = 0;
-				return *this;
-			}
-			//範囲の大きさ(X軸方向)を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Rect& clearWidth() noexcept {
-				this->width = 0;
-				return *this;
-			}
-			//範囲の大きさ(Y軸方向)を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Rect& clearHeight() noexcept {
-				this->height = 0;
-				return *this;
-			}
-			//塗り値を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Rect& clearValue() noexcept {
-				const Matrix_Int_ new_draw_value{};
-				this->draw_value = new_draw_value;
-				return *this;
-			}
-			//始点座標(X,Y)を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Rect& clearPoint() noexcept {
-				this->clearPointX();
-				this->clearPointY();
-				return *this;
-			}
-			//描画範囲を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Rect& clearRange() noexcept {
-				this->clearPointX();
-				this->clearPointY();
-				this->clearWidth();
-				this->clearHeight();
-				return *this;
-			}
-			//全ての値を初期値に戻す
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Rect& clear() noexcept {
-				this->clearRange();
-				this->clearValue();
-				return *this;
-			}
-
-
-			///// 代入 /////
-
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Rect& setPointX(const Index_Size end_x_) noexcept {
-				this->start_x = end_x_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Rect& setPointY(const Index_Size end_y_) noexcept {
-				this->start_y = end_y_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Rect& setWidth(const Index_Size width_) noexcept {
-				this->width = width_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Rect& setHeight(const Index_Size height_) noexcept {
-				this->height = height_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Rect& setValue(const Matrix_Int_& draw_value_) noexcept {
-				this->draw_value = draw_value_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Rect& setPoint(const Index_Size point_) noexcept {
-				this->start_x = point_;
-				this->start_y = point_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Rect& setPoint(const Index_Size end_x_, const Index_Size end_y_) noexcept {
-				this->start_x = end_x_;
-				this->start_y = end_y_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Rect& setRange(const Index_Size end_x_, const Index_Size end_y_, const Index_Size length_) noexcept {
-				this->start_x = end_x_;
-				this->start_y = end_y_;
-				this->width = length_;
-				this->height = length_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Rect& setRange(const Index_Size end_x_, const Index_Size end_y_, const Index_Size width_, const Index_Size height_) noexcept {
-				this->start_x = end_x_;
-				this->start_y = end_y_;
-				this->width = width_;
-				this->height = height_;
-				return *this;
-			}
-			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
-				Rect& setRange(const dtl::base::MatrixRange& matrix_range_) noexcept {
-				this->start_x = matrix_range_.x;
-				this->start_y = matrix_range_.y;
-				this->width = matrix_range_.w;
-				this->height = matrix_range_.h;
-				return *this;
-			}
-
-
 			///// コンストラクタ /////
 
-			constexpr Rect() noexcept = default;
-			constexpr explicit Rect(const Matrix_Int_ & draw_value_) noexcept
-				:draw_value(draw_value_) {}
-			constexpr explicit Rect(const dtl::base::MatrixRange & matrix_range_) noexcept
-				:start_x(matrix_range_.x), start_y(matrix_range_.y),
-				width(matrix_range_.w), height(matrix_range_.h) {}
-			constexpr explicit Rect(const dtl::base::MatrixRange & matrix_range_, const Matrix_Int_ & draw_value_) noexcept
-				:start_x(matrix_range_.x), start_y(matrix_range_.y),
-				width(matrix_range_.w), height(matrix_range_.h),
-				draw_value(draw_value_) {}
-			constexpr explicit Rect(const Index_Size end_x_, const Index_Size end_y_, const Index_Size width_, const Index_Size height_) noexcept
-				:start_x(end_x_), start_y(end_y_),
-				width(width_), height(height_) {}
-			constexpr explicit Rect(const Index_Size end_x_, const Index_Size end_y_, const Index_Size width_, const Index_Size height_, const Matrix_Int_ & draw_value_) noexcept
-				:start_x(end_x_), start_y(end_y_),
-				width(width_), height(height_),
-				draw_value(draw_value_) {}
+			using ShapeBase_t::ShapeBase_t;
 		};
 	}
 }

--- a/include/Utility/RectBaseWithValue.hpp
+++ b/include/Utility/RectBaseWithValue.hpp
@@ -1,0 +1,232 @@
+/*#######################################################################################
+	Made by Kasugaccho
+	https://github.com/Kasugaccho/DungeonTemplateLibrary
+	wanotaitei@gmail.com
+
+	This code is licensed under CC0.
+#######################################################################################*/
+#ifndef INCLUDED_DUNGEON_TEMPLATE_LIBRARY_UTILITY_RECT_BASE_WITH_VALUE_HPP
+#define INCLUDED_DUNGEON_TEMPLATE_LIBRARY_UTILITY_RECT_BASE_WITH_VALUE_HPP
+
+/* Character Code : UTF-8 (BOM) */
+/* Bug Check : not checked */
+
+#include <cstddef>
+#include <Macros/nodiscard.hpp>
+#include <Macros/constexpr.hpp>
+
+//共有データ
+namespace dtl {
+	inline namespace utility {
+
+		//四角形クラス
+		template<typename Derived, typename Matrix_Int_>
+		class RectBaseWithValue {
+		private:
+
+			///// エイリアス /////
+
+			using Index_Size = std::size_t;
+
+
+		protected:
+
+
+			///// メンバ変数 /////
+
+			Index_Size start_x{};
+			Index_Size start_y{};
+			Index_Size width{};
+			Index_Size height{};
+			Matrix_Int_ draw_value{};
+
+
+			///// 計算補助 /////
+
+			constexpr Index_Size calcEndX(const Index_Size max_x_) const noexcept {
+				return (this->width == 0 || this->start_x + this->width >= max_x_)
+					? max_x_
+					: this->start_x + this->width;
+			}
+
+			constexpr Index_Size calcEndY(const Index_Size max_y_) const noexcept {
+				return (this->height == 0 || this->start_y + this->height >= max_y_)
+					? max_y_
+					: this->start_y + this->height;
+			}
+
+
+		public:
+
+
+			///// 情報取得 /////
+
+			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
+			constexpr Index_Size getPointX() const noexcept {
+				return this->start_x;
+			}
+			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
+			constexpr Index_Size getPointY() const noexcept {
+				return this->start_y;
+			}
+			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
+			constexpr Index_Size getWidth() const noexcept {
+				return this->width;
+			}
+			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
+			constexpr Index_Size getHeight() const noexcept {
+				return this->height;
+			}
+			DUNGEON_TEMPLATE_LIBRARY_NODISCARD
+			constexpr Matrix_Int_ getValue() const noexcept {
+				return this->draw_value;
+			}
+
+
+			///// 消去 /////
+
+			//始点座標Xを初期値に戻す
+			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
+				Derived& clearPointX() noexcept {
+				this->start_x = 0;
+				return static_cast<Derived&>(*this);
+			}
+			//始点座標Yを初期値に戻す
+			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
+				Derived& clearPointY() noexcept {
+				this->start_y = 0;
+				return static_cast<Derived&>(*this);
+			}
+			//範囲の大きさ(X軸方向)を初期値に戻す
+			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
+				Derived& clearWidth() noexcept {
+				this->width = 0;
+				return static_cast<Derived&>(*this);
+			}
+			//範囲の大きさ(Y軸方向)を初期値に戻す
+			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
+				Derived& clearHeight() noexcept {
+				this->height = 0;
+				return static_cast<Derived&>(*this);
+			}
+			//塗り値を初期値に戻す
+			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
+				Derived& clearValue() noexcept {
+				const Matrix_Int_ new_draw_value{};
+				this->draw_value = new_draw_value;
+				return static_cast<Derived&>(*this);
+			}
+			//始点座標(X,Y)を初期値に戻す
+			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
+				Derived& clearPoint() noexcept {
+				this->clearPointX();
+				this->clearPointY();
+				return static_cast<Derived&>(*this);
+			}
+			//描画範囲を初期値に戻す
+			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
+				Derived& clearRange() noexcept {
+				this->clearPointX();
+				this->clearPointY();
+				this->clearWidth();
+				this->clearHeight();
+				return static_cast<Derived&>(*this);
+			}
+			//全ての値を初期値に戻す
+			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
+				Derived& clear() noexcept {
+				this->clearRange();
+				this->clearValue();
+				return static_cast<Derived&>(*this);
+			}
+
+
+			///// 代入 /////
+
+			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
+				Derived& setPointX(const Index_Size start_x_) noexcept {
+				this->start_x = start_x_;
+				return static_cast<Derived&>(*this);
+			}
+			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
+				Derived& setPointY(const Index_Size start_y_) noexcept {
+				this->start_y = start_y_;
+				return static_cast<Derived&>(*this);
+			}
+			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
+				Derived& setWidth(const Index_Size width_) noexcept {
+				this->width = width_;
+				return static_cast<Derived&>(*this);
+			}
+			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
+				Derived& setHeight(const Index_Size height_) noexcept {
+				this->height = height_;
+				return static_cast<Derived&>(*this);
+			}
+			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
+				Derived& setValue(const Matrix_Int_& draw_value_) noexcept {
+				this->draw_value = draw_value_;
+				return static_cast<Derived&>(*this);
+			}
+			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
+				Derived& setPoint(const Index_Size point_) noexcept {
+				this->start_x = point_;
+				this->start_y = point_;
+				return static_cast<Derived&>(*this);
+			}
+			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
+				Derived& setPoint(const Index_Size start_x_, const Index_Size start_y_) noexcept {
+				this->start_x = start_x_;
+				this->start_y = start_y_;
+				return static_cast<Derived&>(*this);
+			}
+			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
+				Derived& setRange(const Index_Size start_x_, const Index_Size start_y_, const Index_Size length_) noexcept {
+				this->start_x = start_x_;
+				this->start_y = start_y_;
+				this->width = length_;
+				this->height = length_;
+				return static_cast<Derived&>(*this);
+			}
+			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
+				Derived& setRange(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_) noexcept {
+				this->start_x = start_x_;
+				this->start_y = start_y_;
+				this->width = width_;
+				this->height = height_;
+				return static_cast<Derived&>(*this);
+			}
+			DUNGEON_TEMPLATE_LIBRARY_CPP14_CONSTEXPR
+				Derived& setRange(const dtl::base::MatrixRange& matrix_range_) noexcept {
+				this->start_x = matrix_range_.x;
+				this->start_y = matrix_range_.y;
+				this->width = matrix_range_.w;
+				this->height = matrix_range_.h;
+				return static_cast<Derived&>(*this);
+			}
+
+
+			///// コンストラクタ /////
+
+			constexpr RectBaseWithValue() noexcept = default;
+			constexpr explicit RectBaseWithValue(const Matrix_Int_ & draw_value_) noexcept
+				:draw_value(draw_value_) {}
+			constexpr explicit RectBaseWithValue(const dtl::base::MatrixRange & matrix_range_) noexcept
+				:start_x(matrix_range_.x), start_y(matrix_range_.y),
+				width(matrix_range_.w), height(matrix_range_.h) {}
+			constexpr explicit RectBaseWithValue(const dtl::base::MatrixRange & matrix_range_, const Matrix_Int_ & draw_value_) noexcept
+				:start_x(matrix_range_.x), start_y(matrix_range_.y),
+				width(matrix_range_.w), height(matrix_range_.h),
+				draw_value(draw_value_) {}
+			constexpr explicit RectBaseWithValue(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_) noexcept
+				:start_x(start_x_), start_y(start_y_),
+				width(width_), height(height_) {}
+			constexpr explicit RectBaseWithValue(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_, const Matrix_Int_ & draw_value_) noexcept
+				:start_x(start_x_), start_y(start_y_),
+				width(width_), height(height_),
+				draw_value(draw_value_) {}
+		};
+	}
+}
+
+#endif //Included Dungeon Template Library


### PR DESCRIPTION
お試しで四角形＋描画値のメンバ変数があるものについて、新たに
RectBaseWithValue クラステンプレートを作成し、対応するクラス
テンプレートを CRTP に変更しました。

変更量は多いですが、RectBaseWithValue にまとめただけです。
もし CRTP がお好みで無ければ遠慮なくリジェクトしてください。

もし気に入って頂けたら他の Shape 群も同様にグルーピングして
PullRequest したいと思います。

なお、当方 Visual Studio をうまく扱えてないので、取り込む場合には
Visual Studio 側の追加変更が必要かもしれません…（すみません…