### PR TITLE
MatrixView::draw:複雑な式中でローカル変数を使用

### DIFF
--- a/include/Camera/MatrixView.hpp
+++ b/include/Camera/MatrixView.hpp
@@ -125,8 +125,8 @@ namespace dtl {
 				}
 				const std::int_fast32_t target_int_x{ static_cast<std::int_fast32_t>(this->target_x) };
 				const std::int_fast32_t target_int_y{ static_cast<std::int_fast32_t>(this->target_y) };
-				const std::int_fast32_t draw_position_x{ (this->target_x == static_cast<double>(static_cast<std::int_fast32_t>(this->target_x))) ? this->window_center_x : this->window_center_x - static_cast<std::int_fast32_t>((this->target_x - static_cast<double>(static_cast<std::int_fast32_t>(this->target_x))) * static_cast<double>(this->pixel_width)) };
-				const std::int_fast32_t draw_position_y{ (this->target_y == static_cast<double>(static_cast<std::int_fast32_t>(this->target_y))) ? this->window_center_y : this->window_center_y - static_cast<std::int_fast32_t>((this->target_y - static_cast<double>(static_cast<std::int_fast32_t>(this->target_y))) * static_cast<double>(this->pixel_height)) };
+				const std::int_fast32_t draw_position_x{ (this->target_x == static_cast<double>(target_int_x)) ? this->window_center_x : this->window_center_x - static_cast<std::int_fast32_t>((this->target_x - static_cast<double>(target_int_x)) * static_cast<double>(this->pixel_width)) };
+				const std::int_fast32_t draw_position_y{ (this->target_y == static_cast<double>(target_int_y)) ? this->window_center_y : this->window_center_y - static_cast<std::int_fast32_t>((this->target_y - static_cast<double>(target_int_y)) * static_cast<double>(this->pixel_height)) };
 
 				MatrixViewRect rect{};
 


### PR DESCRIPTION
draw_position_[xy] 算出の式中に

static_cast<std::int_fast32_t>(this->target_[xy])

が 2 回出てくるのですが、この値は直前で target_int_[xy] としてローカル
変数定義されているので、そちらを使うように修正しました。