### PR TITLE
fix: support clang3.4.2 (重要注意事項あり)

### DIFF
--- a/include/DTL/Base/Struct.hpp
+++ b/include/DTL/Base/Struct.hpp
@@ -19,7 +19,7 @@ namespace dtl {
 		template<typename Int_>
 		struct Coordinate1Dimensional {
 			Int_ x{};
-			constexpr Coordinate1Dimensional() noexcept = default;
+			constexpr Coordinate1Dimensional() = default;
 			constexpr Coordinate1Dimensional(const Int_& x_) noexcept :x(x_) {};
 		};
 
@@ -27,7 +27,7 @@ namespace dtl {
 		struct Coordinate2Dimensional {
 			Int_ x{};
 			Int_ y{};
-			constexpr Coordinate2Dimensional() noexcept = default;
+			constexpr Coordinate2Dimensional() = default;
 			constexpr Coordinate2Dimensional(const Int_& x_, const Int_& y_) noexcept :x(x_), y(y_) {};
 
 			constexpr bool operator==(const ::dtl::base::Coordinate2Dimensional<Int_>& vec2_) const noexcept {
@@ -46,7 +46,7 @@ namespace dtl {
 			Int_ y{};
 			Int_ w{};
 			Int_ h{};
-			constexpr Coordinate2DimensionalAndLength2Dimensional() noexcept = default;
+			constexpr Coordinate2DimensionalAndLength2Dimensional() = default;
 			constexpr Coordinate2DimensionalAndLength2Dimensional(const Int_& x_, const Int_& y_) noexcept
 				:x(x_), y(y_) {};
 			constexpr Coordinate2DimensionalAndLength2Dimensional(const Int_& x_, const Int_& y_, const Int_& l_) noexcept

--- a/include/DTL/Board/WriteNumber.hpp
+++ b/include/DTL/Board/WriteNumber.hpp
@@ -10,6 +10,7 @@
 #ifndef INCLUDED_DUNGEON_TEMPLATE_LIBRARY_DTL_BOARD_WRITE_NUMBER_HPP
 #define INCLUDED_DUNGEON_TEMPLATE_LIBRARY_DTL_BOARD_WRITE_NUMBER_HPP
 
+#include <DTL/Workaround/cstdioGets.hpp>
 #include <sstream>
 #include <string>
 #include <DTL/Base/Struct.hpp>

--- a/include/DTL/Board/WriteNumber.hpp
+++ b/include/DTL/Board/WriteNumber.hpp
@@ -371,7 +371,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr WriteNumber() noexcept = default;
+			constexpr WriteNumber() = default;
 
 			constexpr explicit WriteNumber(const OutputString_& new_line_string_) noexcept
 				:new_line_string(new_line_string_) {}

--- a/include/DTL/Camera/MatrixView.hpp
+++ b/include/DTL/Camera/MatrixView.hpp
@@ -18,7 +18,7 @@ namespace dtl {
 	inline namespace camera {
 
 		struct MatrixViewRect {
-			constexpr MatrixViewRect() noexcept = default;
+			constexpr MatrixViewRect() = default;
 			std::int_fast32_t start_x{};
 			std::int_fast32_t start_y{};
 			std::int_fast32_t end_x{};
@@ -27,7 +27,7 @@ namespace dtl {
 
 		class SampleMatrixViewDraw {
 		public:
-			constexpr SampleMatrixViewDraw() noexcept = default;
+			constexpr SampleMatrixViewDraw() = default;
 			template<typename Matrix_> //maybe_unused
 			DTL_VERSIONING_CPP14_CONSTEXPR
 				void draw(const Matrix_&, const std::int_fast32_t, const std::int_fast32_t, const std::int_fast32_t, const std::int_fast32_t, const std::int_fast32_t, const std::int_fast32_t, const std::int_fast32_t, const std::int_fast32_t) const noexcept {}
@@ -79,7 +79,7 @@ namespace dtl {
 			}
 
 			//コンストラクタ
-			constexpr MatrixView() noexcept = default;
+			constexpr MatrixView() = default;
 			constexpr MatrixView(const std::int_fast32_t window_width_, const std::int_fast32_t window_height_, const std::int_fast32_t pixel_width_, const std::int_fast32_t pixel_height_, const double target_x_, const double target_y_) noexcept
 				:window_width(window_width_),
 				window_height(window_height_),

--- a/include/DTL/Console/OutputNumber.hpp
+++ b/include/DTL/Console/OutputNumber.hpp
@@ -399,7 +399,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 			
-			constexpr OutputNumber() noexcept = default;
+			constexpr OutputNumber() = default;
 			constexpr explicit OutputNumber(const OutputString_ & draw_string_) noexcept
 				:after_string(draw_string_) {}
 			constexpr explicit OutputNumber(const OutputString_ & before_draw_string_, const OutputString_ & draw_string_) noexcept

--- a/include/DTL/Console/OutputNumber.hpp
+++ b/include/DTL/Console/OutputNumber.hpp
@@ -10,6 +10,7 @@
 #ifndef INCLUDED_DUNGEON_TEMPLATE_LIBRARY_DTL_CONSOLE_OUTPUT_NUMBER_HPP
 #define INCLUDED_DUNGEON_TEMPLATE_LIBRARY_DTL_CONSOLE_OUTPUT_NUMBER_HPP
 
+#include <DTL/Workaround/cstdioGets.hpp>
 #include <iostream>
 #include <string>
 #include <DTL/Base/Struct.hpp>

--- a/include/DTL/Console/OutputString.hpp
+++ b/include/DTL/Console/OutputString.hpp
@@ -10,6 +10,7 @@
 #ifndef INCLUDED_DUNGEON_TEMPLATE_LIBRARY_DTL_CONSOLE_OUTPUT_STRING_HPP
 #define INCLUDED_DUNGEON_TEMPLATE_LIBRARY_DTL_CONSOLE_OUTPUT_STRING_HPP
 
+#include <DTL/Workaround/cstdioGets.hpp>
 #include <iostream>
 #include <string>
 #include <vector>

--- a/include/DTL/Console/OutputString.hpp
+++ b/include/DTL/Console/OutputString.hpp
@@ -387,7 +387,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 			
-			constexpr OutputString() noexcept = default;
+			constexpr OutputString() = default;
 			template<typename ...Args_>
 			explicit OutputString(const OutputStringName_ & first_, const Args_ & ... args_) noexcept {
 				this->string_String(first_, args_...);

--- a/include/DTL/Console/OutputStringBool.hpp
+++ b/include/DTL/Console/OutputStringBool.hpp
@@ -10,6 +10,7 @@
 #ifndef INCLUDED_DUNGEON_TEMPLATE_LIBRARY_DTL_CONSOLE_OUTPUT_STRING_BOOL_HPP
 #define INCLUDED_DUNGEON_TEMPLATE_LIBRARY_DTL_CONSOLE_OUTPUT_STRING_BOOL_HPP
 
+#include <DTL/Workaround/cstdioGets.hpp>
 #include <iostream>
 #include <string>
 #include <DTL/Base/Struct.hpp>

--- a/include/DTL/Console/OutputStringBool.hpp
+++ b/include/DTL/Console/OutputStringBool.hpp
@@ -455,7 +455,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr OutputStringBool() noexcept = default;
+			constexpr OutputStringBool() = default;
 			constexpr explicit OutputStringBool(const OutputString_ & true_string_) noexcept
 				:true_string(true_string_) {}
 			constexpr explicit OutputStringBool(const OutputString_ & true_string_, const OutputString_ & false_string_) noexcept

--- a/include/DTL/Console/OutputView.hpp
+++ b/include/DTL/Console/OutputView.hpp
@@ -352,7 +352,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr OutputView() noexcept = default;
+			constexpr OutputView() = default;
 			constexpr explicit OutputView(const OutputView_& view_) noexcept
 				:view_width(view_), view_height(view_) {}
 			constexpr explicit OutputView(const OutputView_& view_width_, const OutputView_& view_height_) noexcept

--- a/include/DTL/Console/OutputView.hpp
+++ b/include/DTL/Console/OutputView.hpp
@@ -10,6 +10,7 @@
 #ifndef INCLUDED_DUNGEON_TEMPLATE_LIBRARY_DTL_CONSOLE_OUTPUT_VIEW_HPP
 #define INCLUDED_DUNGEON_TEMPLATE_LIBRARY_DTL_CONSOLE_OUTPUT_VIEW_HPP
 
+#include <DTL/Workaround/cstdioGets.hpp>
 #include <iostream>
 #include <string>
 #include <DTL/Base/Struct.hpp>

--- a/include/DTL/Deprecated/BoardGame.hpp
+++ b/include/DTL/Deprecated/BoardGame.hpp
@@ -312,7 +312,7 @@ namespace dtl {
 				class Chess {
 				public:
 					//コンストラクタ
-					constexpr Chess() noexcept = default;
+					constexpr Chess() = default;
 					template<typename Matrix_>
 					DTL_VERSIONING_CPP14_CONSTEXPR
 						explicit Chess(Matrix_& matrix_) noexcept {
@@ -360,7 +360,7 @@ namespace dtl {
 				class Chess {
 				public:
 					//コンストラクタ
-					constexpr Chess() noexcept = default;
+					constexpr Chess() = default;
 					template<typename Matrix_>
 					DTL_VERSIONING_CPP14_CONSTEXPR
 						explicit Chess(Matrix_& matrix_, const ::dtl::type::size x_, const ::dtl::type::size y_) noexcept {
@@ -546,7 +546,7 @@ namespace dtl {
 						return true;
 					}
 					//コンストラクタ
-					constexpr KnightTour() noexcept = default;
+					constexpr KnightTour() = default;
 					template<typename Matrix_>
 					explicit KnightTour(Matrix_ & matrix_, const ::dtl::type::size x_, const ::dtl::type::size y_, const ::dtl::type::size start_x_ = 0, const ::dtl::type::size start_y_ = 0, const bool is_closed_ = false, const Matrix_Int_ mod_value_ = 0) noexcept {
 						create(matrix_, x_, y_, start_x_, start_y_, is_closed_, mod_value_);

--- a/include/DTL/Deprecated/DungeonFile.hpp
+++ b/include/DTL/Deprecated/DungeonFile.hpp
@@ -9,6 +9,7 @@
 #ifndef INCLUDED_DUNGEON_TEMPLATE_LIBRARY_DTL_DUNGEON_FILE_HPP
 #define INCLUDED_DUNGEON_TEMPLATE_LIBRARY_DTL_DUNGEON_FILE_HPP
 
+#include <DTL/Workaround/cstdioGets.hpp>
 #include <cstdint>
 #include <fstream>
 #include <string>

--- a/include/DTL/Deprecated/DungeonNoise.hpp
+++ b/include/DTL/Deprecated/DungeonNoise.hpp
@@ -9,6 +9,7 @@
 #ifndef INCLUDED_DUNGEON_TEMPLATE_LIBRARY_DTL_DUNGEON_NOISE_HPP
 #define INCLUDED_DUNGEON_TEMPLATE_LIBRARY_DTL_DUNGEON_NOISE_HPP
 
+#include <DTL/Workaround/cstdioGets.hpp>
 #include <DTL/Random/MersenneTwister32bit.hpp>
 #include <DTL/Macros/nodiscard.hpp>
 #include <DTL/Macros/constexpr.hpp>

--- a/include/DTL/Deprecated/DungeonPaint.hpp
+++ b/include/DTL/Deprecated/DungeonPaint.hpp
@@ -32,7 +32,7 @@ namespace dtl {
 		class Bucket {
 		public:
 			//コンストラクタ
-			constexpr Bucket() noexcept = default;
+			constexpr Bucket() = default;
 			template<typename Matrix_>
 			DTL_VERSIONING_CPP14_CONSTEXPR
 				explicit Bucket(Matrix_& matrix_, const std::int_fast32_t col_, const std::int_fast32_t row_, const Matrix_Int_ paint_value_) noexcept {

--- a/include/DTL/Deprecated/RogueLike.hpp
+++ b/include/DTL/Deprecated/RogueLike.hpp
@@ -25,7 +25,7 @@ namespace dtl {
 				//四角形の位置と大きさ
 				template<typename Matrix_Int_>
 				struct RogueLikeOutputNumber {
-					constexpr RogueLikeOutputNumber() noexcept = default;
+					constexpr RogueLikeOutputNumber() = default;
 					//位置
 					Matrix_Int_ x{}, y{};
 					//大きさ
@@ -52,7 +52,7 @@ namespace dtl {
 				class RogueLike {
 				public:
 					//コンストラクタ
-					constexpr RogueLike() noexcept = default;
+					constexpr RogueLike() = default;
 					template<typename Matrix_>
 					DTL_VERSIONING_CPP14_CONSTEXPR
 						explicit RogueLike(Matrix_& matrix_, const ::dtl::type::size way_max_ = 20) noexcept {
@@ -282,7 +282,7 @@ namespace dtl {
 				class RogueLikeCave {
 				public:
 					//コンストラクタ
-					constexpr RogueLikeCave() noexcept = default;
+					constexpr RogueLikeCave() = default;
 					template<typename Matrix_>
 					DTL_VERSIONING_CPP14_CONSTEXPR
 						explicit RogueLikeCave(Matrix_& matrix_, const ::dtl::type::size way_max_ = 20) noexcept {

--- a/include/DTL/Macros/nodiscard.hpp
+++ b/include/DTL/Macros/nodiscard.hpp
@@ -12,28 +12,32 @@
 
 ///// DTL_VERSIONING_CPP17_NODISCARDがない場合 /////
 #ifndef DTL_VERSIONING_CPP17_NODISCARD
-#ifdef __has_cpp_attribute
+# if defined(__has_cpp_attribute) && 201402 < __cplusplus
 
-#if __has_cpp_attribute(nodiscard)
-#define DTL_VERSIONING_CPP17_NODISCARD [[nodiscard]]
-#endif
+#   if __has_cpp_attribute(nodiscard)
+#     define DTL_VERSIONING_CPP17_NODISCARD [[nodiscard]]
+#   endif
 
-#elif defined(__clang__)
-#define DTL_VERSIONING_CPP17_NODISCARD __attribute__((warn_unused_result))
+# elif defined(__clang__) || defined(__GNUC__)
+#   define DTL_VERSIONING_CPP17_NODISCARD __attribute__((warn_unused_result))
 
-#elif defined(_MSC_VER)
+# elif defined(_MSC_VER)
+#   if 1911 <= _MSC_VER && 201402 < _MSVC_LANG
+#     define DTL_VERSIONING_CPP17_NODISCARD [[nodiscard]]
+#   else
 // _Must_inspect_result_ expands into this
-#define DTL_VERSIONING_CPP17_NODISCARD                                                                                                                                                                                                                                                                                                \
-  __declspec("SAL_name"                                                                                                                                                                                                                                                                                                        \
-             "("                                                                                                                                                                                                                                                                                                               \
-             "\"_Must_inspect_result_\""                                                                                                                                                                                                                                                                                       \
-             ","                                                                                                                                                                                                                                                                                                               \
-             "\"\""                                                                                                                                                                                                                                                                                                            \
-             ","                                                                                                                                                                                                                                                                                                               \
-             "\"2\""                                                                                                                                                                                                                                                                                                           \
-             ")") __declspec("SAL_begin") __declspec("SAL_post") __declspec("SAL_mustInspect") __declspec("SAL_post") __declspec("SAL_checkReturn") __declspec("SAL_end")
+#     define DTL_VERSIONING_CPP17_NODISCARD                                                                                                                                                                                                                                                                                                \
+      __declspec( "SAL_name"                                                                                                                                                                                                                                                                                                        \
+                  "("                                                                                                                                                                                                                                                                                                               \
+                  "\"_Must_inspect_result_\""                                                                                                                                                                                                                                                                                       \
+                  ","                                                                                                                                                                                                                                                                                                               \
+                  "\"\""                                                                                                                                                                                                                                                                                                            \
+                  ","                                                                                                                                                                                                                                                                                                               \
+                  "\"2\""                                                                                                                                                                                                                                                                                                           \
+                  ")") __declspec("SAL_begin") __declspec("SAL_post") __declspec("SAL_mustInspect") __declspec("SAL_post") __declspec("SAL_checkReturn") __declspec("SAL_end")
+#   endif
 
-#endif
+# endif
 #endif
 
 ///// もしDTL_VERSIONING_CPP17_NODISCARDが無かったらつくる /////

--- a/include/DTL/Retouch/BuryPoint.hpp
+++ b/include/DTL/Retouch/BuryPoint.hpp
@@ -377,7 +377,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr BuryPoint() noexcept = default;
+			constexpr BuryPoint() = default;
 			constexpr explicit BuryPoint(const ::dtl::base::MatrixRange& matrix_range_) noexcept
 				:start_x(matrix_range_.x), start_y(matrix_range_.y),
 				width(matrix_range_.w), height(matrix_range_.h) {}

--- a/include/DTL/Retouch/RemovePoint.hpp
+++ b/include/DTL/Retouch/RemovePoint.hpp
@@ -377,7 +377,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr RemovePoint() noexcept = default;
+			constexpr RemovePoint() = default;
 			constexpr explicit RemovePoint(const ::dtl::base::MatrixRange& matrix_range_) noexcept
 				:start_x(matrix_range_.x), start_y(matrix_range_.y),
 				width(matrix_range_.w), height(matrix_range_.h) {}

--- a/include/DTL/Shape/AbsoluteMemberRect.hpp
+++ b/include/DTL/Shape/AbsoluteMemberRect.hpp
@@ -248,7 +248,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr AbsoluteMemberRect() noexcept = default;
+			constexpr AbsoluteMemberRect() = default;
 			constexpr explicit AbsoluteMemberRect(const Matrix_Int_& draw_value_) noexcept
 				:absoluteRect(draw_value_) {}
 			constexpr explicit AbsoluteMemberRect(const ::dtl::base::MatrixRange& matrix_range_) noexcept

--- a/include/DTL/Shape/Border.hpp
+++ b/include/DTL/Shape/Border.hpp
@@ -530,7 +530,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr Border() noexcept = default;
+			constexpr Border() = default;
 			constexpr explicit Border(const Matrix_Int_ & draw_value_) noexcept
 				:draw_value(draw_value_) {}
 			constexpr explicit Border(const ::dtl::base::MatrixRange & matrix_range_) noexcept

--- a/include/DTL/Shape/BorderOdd.hpp
+++ b/include/DTL/Shape/BorderOdd.hpp
@@ -564,7 +564,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr BorderOdd() noexcept = default;
+			constexpr BorderOdd() = default;
 			constexpr explicit BorderOdd(const Matrix_Int_ & draw_value_) noexcept
 				:draw_value(draw_value_) {}
 			constexpr explicit BorderOdd(const ::dtl::base::MatrixRange & matrix_range_) noexcept

--- a/include/DTL/Shape/CellularAutomatonIsland.hpp
+++ b/include/DTL/Shape/CellularAutomatonIsland.hpp
@@ -295,7 +295,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr CellularAutomatonIsland() noexcept = default;
+			constexpr CellularAutomatonIsland() = default;
 			constexpr explicit CellularAutomatonIsland(const Matrix_Int_ & draw_value_) noexcept
 				:randomRect(draw_value_) {}
 

--- a/include/DTL/Shape/CellularAutomatonMixIsland.hpp
+++ b/include/DTL/Shape/CellularAutomatonMixIsland.hpp
@@ -295,7 +295,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr CellularAutomatonMixIsland() noexcept = default;
+			constexpr CellularAutomatonMixIsland() = default;
 			template<typename ...Args_>
 			explicit CellularAutomatonMixIsland(const Index_Size & loop_num_, const Matrix_Int_ & first_, const Args_ & ... args_) noexcept
 				:border(first_), mixRect(first_, args_...), loop_num(loop_num_) {}

--- a/include/DTL/Shape/DiamondSquareAverageCornerIsland.hpp
+++ b/include/DTL/Shape/DiamondSquareAverageCornerIsland.hpp
@@ -299,7 +299,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr DiamondSquareAverageCornerIsland() noexcept = default;
+			constexpr DiamondSquareAverageCornerIsland() = default;
 			constexpr explicit DiamondSquareAverageCornerIsland(const Matrix_Int_ & min_value_) noexcept
 				:min_value(min_value_) {}
 			constexpr explicit DiamondSquareAverageCornerIsland(const Matrix_Int_ & min_value_, const Matrix_Int_ & altitude_) noexcept

--- a/include/DTL/Shape/DiamondSquareAverageIsland.hpp
+++ b/include/DTL/Shape/DiamondSquareAverageIsland.hpp
@@ -311,7 +311,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr DiamondSquareAverageIsland() noexcept = default;
+			constexpr DiamondSquareAverageIsland() = default;
 			constexpr explicit DiamondSquareAverageIsland(const Matrix_Int_ & min_value_) noexcept
 				:min_value(min_value_) {}
 			constexpr explicit DiamondSquareAverageIsland(const Matrix_Int_ & min_value_, const Matrix_Int_ & altitude_) noexcept

--- a/include/DTL/Shape/FractalIsland.hpp
+++ b/include/DTL/Shape/FractalIsland.hpp
@@ -354,7 +354,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr FractalIsland() noexcept = default;
+			constexpr FractalIsland() = default;
 			constexpr explicit FractalIsland(const Matrix_Int_ & min_value_) noexcept
 				:min_value(min_value_) {}
 			constexpr explicit FractalIsland(const Matrix_Int_ & min_value_, const Matrix_Int_ & altitude_) noexcept

--- a/include/DTL/Shape/FractalLoopIsland.hpp
+++ b/include/DTL/Shape/FractalLoopIsland.hpp
@@ -360,7 +360,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr FractalLoopIsland() noexcept = default;
+			constexpr FractalLoopIsland() = default;
 			constexpr explicit FractalLoopIsland(const Matrix_Int_ & min_value_) noexcept
 				:min_value(min_value_) {}
 			constexpr explicit FractalLoopIsland(const Matrix_Int_ & min_value_, const Matrix_Int_ & altitude_) noexcept

--- a/include/DTL/Shape/HalfMixRect.hpp
+++ b/include/DTL/Shape/HalfMixRect.hpp
@@ -449,7 +449,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr HalfMixRect() noexcept = default;
+			constexpr HalfMixRect() = default;
 			template<typename ...Args_>
 			explicit HalfMixRect(const Matrix_Int_ & first_, const Args_ & ... args_) noexcept {
 				this->string_String(first_, args_...);

--- a/include/DTL/Shape/MazeDig.hpp
+++ b/include/DTL/Shape/MazeDig.hpp
@@ -493,7 +493,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr MazeDig() noexcept = default;
+			constexpr MazeDig() = default;
 			constexpr explicit MazeDig(const Matrix_Int_ & empty_value_) noexcept
 				:empty_value(empty_value_) {}
 			constexpr explicit MazeDig(const Matrix_Int_& empty_value_, const Matrix_Int_& wall_value_) noexcept

--- a/include/DTL/Shape/MixRect.hpp
+++ b/include/DTL/Shape/MixRect.hpp
@@ -447,7 +447,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr MixRect() noexcept = default;
+			constexpr MixRect() = default;
 			template<typename ...Args_>
 			explicit MixRect(const Matrix_Int_ & first_, const Args_ & ... args_) noexcept {
 				this->string_String(first_, args_...);

--- a/include/DTL/Shape/Point.hpp
+++ b/include/DTL/Shape/Point.hpp
@@ -49,7 +49,7 @@ namespace dtl {
 			class Point {
 			private:
 			public:
-				constexpr Point() noexcept = default;
+				constexpr Point() = default;
 				template<typename Matrix_>
 				DTL_VERSIONING_CPP14_CONSTEXPR
 					void draw(Matrix_& matrix_, const ::dtl::type::size x_, const ::dtl::type::size y_) const noexcept {
@@ -122,7 +122,7 @@ namespace dtl {
 			class Point {
 			private:
 			public:
-				constexpr Point() noexcept = default;
+				constexpr Point() = default;
 
 			};
 

--- a/include/DTL/Shape/PointGrid.hpp
+++ b/include/DTL/Shape/PointGrid.hpp
@@ -467,7 +467,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr PointGrid() noexcept = default;
+			constexpr PointGrid() = default;
 			constexpr explicit PointGrid(const Matrix_Int_ & draw_value_) noexcept
 				:draw_value(draw_value_) {}
 			constexpr explicit PointGrid(const ::dtl::base::MatrixRange & matrix_range_) noexcept

--- a/include/DTL/Shape/PointGridAndSomeBlocksWithBorder.hpp
+++ b/include/DTL/Shape/PointGridAndSomeBlocksWithBorder.hpp
@@ -290,7 +290,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr PointGridAndSomeBlocksWithBorder() noexcept = default;
+			constexpr PointGridAndSomeBlocksWithBorder() = default;
 			constexpr explicit PointGridAndSomeBlocksWithBorder(const Matrix_Int_& draw_value_) noexcept
 				:randomRect(draw_value_), borderOdd(draw_value_), pointGrid(draw_value_) {}
 			constexpr explicit PointGridAndSomeBlocksWithBorder(const Matrix_Int_& draw_value_, const Matrix_Int_& draw_value2_) noexcept

--- a/include/DTL/Shape/PointGridWithBorder.hpp
+++ b/include/DTL/Shape/PointGridWithBorder.hpp
@@ -273,7 +273,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr PointGridWithBorder() noexcept = default;
+			constexpr PointGridWithBorder() = default;
 			constexpr explicit PointGridWithBorder(const Matrix_Int_& draw_value_) noexcept
 				:borderOdd(draw_value_), pointGrid(draw_value_) {}
 			constexpr explicit PointGridWithBorder(const Matrix_Int_& draw_value_, const Matrix_Int_& draw_value2_) noexcept

--- a/include/DTL/Shape/RandomRect.hpp
+++ b/include/DTL/Shape/RandomRect.hpp
@@ -430,7 +430,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr RandomRect() noexcept = default;
+			constexpr RandomRect() = default;
 			constexpr explicit RandomRect(const Matrix_Int_ & draw_value_) noexcept
 				:draw_value(draw_value_) {}
 			constexpr explicit RandomRect(const Matrix_Int_ & draw_value_, const double probability_) noexcept

--- a/include/DTL/Shape/RandomVoronoi.hpp
+++ b/include/DTL/Shape/RandomVoronoi.hpp
@@ -285,7 +285,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr RandomVoronoi() noexcept = default;
+			constexpr RandomVoronoi() = default;
 			constexpr explicit RandomVoronoi(const ::dtl::type::size draw_value_) noexcept
 				:voronoiDiagram(draw_value_) {}
 			constexpr explicit RandomVoronoi(const ::dtl::type::size draw_value_, const double probability_value_) noexcept

--- a/include/DTL/Shape/Rect.hpp
+++ b/include/DTL/Shape/Rect.hpp
@@ -517,7 +517,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr Rect() noexcept = default;
+			constexpr Rect() = default;
 			constexpr explicit Rect(const Matrix_Int_ & draw_value_) noexcept
 				:draw_value(draw_value_) {}
 			constexpr explicit Rect(const ::dtl::base::MatrixRange & matrix_range_) noexcept

--- a/include/DTL/Shape/Reversi.hpp
+++ b/include/DTL/Shape/Reversi.hpp
@@ -411,7 +411,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr Reversi() noexcept = default;
+			constexpr Reversi() = default;
 			constexpr explicit Reversi(const Matrix_Int_ & black_value_) noexcept
 				:black_value(black_value_) {}
 			constexpr explicit Reversi(const Matrix_Int_& black_value_, const Matrix_Int_& white_value_) noexcept

--- a/include/DTL/Shape/SimpleRogueLike.hpp
+++ b/include/DTL/Shape/SimpleRogueLike.hpp
@@ -641,7 +641,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr SimpleRogueLike() noexcept = default;
+			constexpr SimpleRogueLike() = default;
 			constexpr explicit SimpleRogueLike(const Matrix_Int_& room_value_) noexcept
 				:room_value(room_value_) {}
 			constexpr explicit SimpleRogueLike(const Matrix_Int_& room_value_, const Matrix_Int_& road_value_) noexcept

--- a/include/DTL/Shape/SimpleVoronoiIsland.hpp
+++ b/include/DTL/Shape/SimpleVoronoiIsland.hpp
@@ -290,7 +290,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr SimpleVoronoiIsland() noexcept = default;
+			constexpr SimpleVoronoiIsland() = default;
 			constexpr explicit SimpleVoronoiIsland(const ::dtl::type::size voronoi_num_) noexcept
 				:voronoiDiagram(voronoi_num_) {}
 			constexpr explicit SimpleVoronoiIsland(const ::dtl::type::size voronoi_num_, const double probability_value_) noexcept

--- a/include/DTL/Shape/Template.hpp
+++ b/include/DTL/Shape/Template.hpp
@@ -365,7 +365,7 @@ namespace dtl {
 
 			/* 非範囲指定版 */
 
-			constexpr SampleDungeon() noexcept = default; //これは固定
+			constexpr SampleDungeon() = default; //これは固定
 
 			constexpr explicit SampleDungeon(const Matrix_Int_ & draw_value_) noexcept
 				:draw_value(draw_value_) {}

--- a/include/DTL/Shape/WhiteNoise.hpp
+++ b/include/DTL/Shape/WhiteNoise.hpp
@@ -429,7 +429,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr WhiteNoise() noexcept = default;
+			constexpr WhiteNoise() = default;
 			constexpr explicit WhiteNoise(const Matrix_Int_ & draw_value_) noexcept
 				:draw_value(draw_value_) {}
 			constexpr explicit WhiteNoise(const ::dtl::base::MatrixRange & matrix_range_) noexcept

--- a/include/DTL/Storage/FileBMP.hpp
+++ b/include/DTL/Storage/FileBMP.hpp
@@ -15,6 +15,7 @@
 	https://github.com/Kasugaccho/DungeonTemplateLibrary/wiki/::dtl::storage::FileBMP-(ストレージクラス)/
 #######################################################################################*/
 
+#include <DTL/Workaround/cstdioGets.hpp>
 #include <fstream>
 #include <string>
 #include <DTL/Base/Struct.hpp>

--- a/include/DTL/Storage/FileBMP.hpp
+++ b/include/DTL/Storage/FileBMP.hpp
@@ -309,7 +309,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr FileBMP() noexcept = default;
+			constexpr FileBMP() = default;
 			constexpr explicit FileBMP(const std::string & write_value_) noexcept
 				:str(write_value_) {}
 			constexpr explicit FileBMP(const std::string & write_value_, const ::dtl::type::size color_num_) noexcept

--- a/include/DTL/Storage/FileHDR.hpp
+++ b/include/DTL/Storage/FileHDR.hpp
@@ -15,6 +15,7 @@
 	https://github.com/Kasugaccho/DungeonTemplateLibrary/wiki/::dtl::storage::FileHDR-(ストレージクラス)/
 #######################################################################################*/
 
+#include <DTL/Workaround/cstdioGets.hpp>
 #include <fstream>
 #include <string>
 #include <DTL/Base/Struct.hpp>

--- a/include/DTL/Storage/FileHDR.hpp
+++ b/include/DTL/Storage/FileHDR.hpp
@@ -309,7 +309,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr FileHDR() noexcept = default;
+			constexpr FileHDR() = default;
 			constexpr explicit FileHDR(const std::string & write_value_) noexcept
 				:str(write_value_) {}
 			constexpr explicit FileHDR(const std::string & write_value_, const ::dtl::type::size color_num_) noexcept

--- a/include/DTL/Storage/FileJPG.hpp
+++ b/include/DTL/Storage/FileJPG.hpp
@@ -310,7 +310,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr FileJPG() noexcept = default;
+			constexpr FileJPG() = default;
 			constexpr explicit FileJPG(const std::string & write_value_) noexcept
 				:str(write_value_) {}
 			constexpr explicit FileJPG(const std::string & write_value_, const ::dtl::type::size color_num_) noexcept

--- a/include/DTL/Storage/FileJPG.hpp
+++ b/include/DTL/Storage/FileJPG.hpp
@@ -15,6 +15,7 @@
 	https://github.com/Kasugaccho/DungeonTemplateLibrary/wiki/::dtl::storage::FileJPG-(ストレージクラス)/
 #######################################################################################*/
 
+#include <DTL/Workaround/cstdioGets.hpp>
 #include <fstream>
 #include <string>
 #include <DTL/Base/Struct.hpp>

--- a/include/DTL/Storage/FileMD.hpp
+++ b/include/DTL/Storage/FileMD.hpp
@@ -435,7 +435,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr FileMD() noexcept = default;
+			constexpr FileMD() = default;
 			constexpr explicit FileMD(const std::string & write_value_) noexcept
 				:str(write_value_) {}
 

--- a/include/DTL/Storage/FileMD.hpp
+++ b/include/DTL/Storage/FileMD.hpp
@@ -15,6 +15,7 @@
 	https://github.com/Kasugaccho/DungeonTemplateLibrary/wiki/::dtl::storage::FileMD-(ストレージクラス)/
 #######################################################################################*/
 
+#include <DTL/Workaround/cstdioGets.hpp>
 #include <fstream>
 #include <string>
 #include <DTL/Base/Struct.hpp>

--- a/include/DTL/Storage/FilePBM.hpp
+++ b/include/DTL/Storage/FilePBM.hpp
@@ -445,7 +445,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr FilePBM() noexcept = default;
+			constexpr FilePBM() = default;
 			constexpr explicit FilePBM(const std::string & write_value_) noexcept
 				:str(write_value_) {}
 

--- a/include/DTL/Storage/FilePBM.hpp
+++ b/include/DTL/Storage/FilePBM.hpp
@@ -15,6 +15,7 @@
 	https://github.com/Kasugaccho/DungeonTemplateLibrary/wiki/::dtl::storage::FilePBM-(ストレージクラス)/
 #######################################################################################*/
 
+#include <DTL/Workaround/cstdioGets.hpp>
 #include <fstream>
 #include <string>
 #include <DTL/Base/Struct.hpp>

--- a/include/DTL/Storage/FilePNG.hpp
+++ b/include/DTL/Storage/FilePNG.hpp
@@ -310,7 +310,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr FilePNG() noexcept = default;
+			constexpr FilePNG() = default;
 			constexpr explicit FilePNG(const std::string & write_value_) noexcept
 				:str(write_value_) {}
 			constexpr explicit FilePNG(const std::string& write_value_, const ::dtl::type::size color_num_) noexcept

--- a/include/DTL/Storage/FilePNG.hpp
+++ b/include/DTL/Storage/FilePNG.hpp
@@ -15,6 +15,7 @@
 	https://github.com/Kasugaccho/DungeonTemplateLibrary/wiki/::dtl::storage::FilePNG-(ストレージクラス)/
 #######################################################################################*/
 
+#include <DTL/Workaround/cstdioGets.hpp>
 #include <fstream>
 #include <string>
 #include <DTL/Base/Struct.hpp>

--- a/include/DTL/Storage/FileTGA.hpp
+++ b/include/DTL/Storage/FileTGA.hpp
@@ -15,6 +15,7 @@
 	https://github.com/Kasugaccho/DungeonTemplateLibrary/wiki/::dtl::storage::FileTGA-(ストレージクラス)/
 #######################################################################################*/
 
+#include <DTL/Workaround/cstdioGets.hpp>
 #include <fstream>
 #include <string>
 #include <DTL/Base/Struct.hpp>

--- a/include/DTL/Storage/FileTGA.hpp
+++ b/include/DTL/Storage/FileTGA.hpp
@@ -309,7 +309,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr FileTGA() noexcept = default;
+			constexpr FileTGA() = default;
 			constexpr explicit FileTGA(const std::string & write_value_) noexcept
 				:str(write_value_) {}
 			constexpr explicit FileTGA(const std::string & write_value_, const ::dtl::type::size color_num_) noexcept

--- a/include/DTL/Storage/FileTXT_0_9.hpp
+++ b/include/DTL/Storage/FileTXT_0_9.hpp
@@ -391,7 +391,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr FileTXT_0_9() noexcept = default;
+			constexpr FileTXT_0_9() = default;
 			constexpr explicit FileTXT_0_9(const std::string & write_value_) noexcept
 				:str(write_value_) {}
 

--- a/include/DTL/Storage/FileTXT_0_9.hpp
+++ b/include/DTL/Storage/FileTXT_0_9.hpp
@@ -15,6 +15,7 @@
 	https://github.com/Kasugaccho/DungeonTemplateLibrary/wiki/::dtl::storage::FileTXT_0_9-(ストレージクラス)/
 #######################################################################################*/
 
+#include <DTL/Workaround/cstdioGets.hpp>
 #include <fstream>
 #include <string>
 #include <DTL/Base/Struct.hpp>

--- a/include/DTL/Storage/FileTerrainOBJ.hpp
+++ b/include/DTL/Storage/FileTerrainOBJ.hpp
@@ -403,7 +403,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr FileTerrainOBJ() noexcept = default;
+			constexpr FileTerrainOBJ() = default;
 			constexpr explicit FileTerrainOBJ(const std::string & write_value_) noexcept
 				:str(write_value_) {}
 			constexpr explicit FileTerrainOBJ(const ::dtl::base::MatrixRange & matrix_range_) noexcept

--- a/include/DTL/Storage/FileTerrainOBJ.hpp
+++ b/include/DTL/Storage/FileTerrainOBJ.hpp
@@ -10,6 +10,7 @@
 #ifndef INCLUDED_DUNGEON_TEMPLATE_LIBRARY_DTL_STORAGE_FILE_TERRAIN_OBJ_HPP
 #define INCLUDED_DUNGEON_TEMPLATE_LIBRARY_DTL_STORAGE_FILE_TERRAIN_OBJ_HPP
 
+#include <DTL/Workaround/cstdioGets.hpp>
 #include <fstream>
 #include <string>
 #include <DTL/Base/Struct.hpp>

--- a/include/DTL/ThirdParty/STB/stb_image_write.h
+++ b/include/DTL/ThirdParty/STB/stb_image_write.h
@@ -42,6 +42,7 @@ LICENSE
 #ifndef INCLUDE_STB_IMAGE_WRITE_H
 #define INCLUDE_STB_IMAGE_WRITE_H
 
+#include <DTL/Workaround/cstdioGets.hpp>
 #include <cstdlib>
 #include <DTL/Type/SizeT.hpp>
 

--- a/include/DTL/Utility/Binarization.hpp
+++ b/include/DTL/Utility/Binarization.hpp
@@ -372,7 +372,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr Binarization() noexcept = default;
+			constexpr Binarization() = default;
 			constexpr explicit Binarization(const Matrix_Int_ & true_value_) noexcept
 				:true_value(true_value_) {}
 			constexpr explicit Binarization(const Matrix_Int_ & true_value_, const Matrix_Int_ & false_value_) noexcept

--- a/include/DTL/Utility/CellularAutomaton.hpp
+++ b/include/DTL/Utility/CellularAutomaton.hpp
@@ -414,7 +414,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr CellularAutomation() noexcept = default;
+			constexpr CellularAutomation() = default;
 			constexpr explicit CellularAutomation(const ::dtl::base::MatrixRange & matrix_range_) noexcept
 				:start_x(matrix_range_.x), start_y(matrix_range_.y),
 				width(matrix_range_.w), height(matrix_range_.h) {}

--- a/include/DTL/Utility/Init.hpp
+++ b/include/DTL/Utility/Init.hpp
@@ -389,7 +389,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr Init() noexcept = default;
+			constexpr Init() = default;
 			constexpr explicit Init(const Matrix_Int_ & draw_value_) noexcept
 				:draw_value(draw_value_) {}
 			constexpr explicit Init(const ::dtl::base::MatrixRange & matrix_range_) noexcept

--- a/include/DTL/Utility/RectBaseWithValue.hpp
+++ b/include/DTL/Utility/RectBaseWithValue.hpp
@@ -207,7 +207,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr RectBaseWithValue() noexcept = default;
+			constexpr RectBaseWithValue() = default;
 			constexpr explicit RectBaseWithValue(const Matrix_Int_ & draw_value_) noexcept
 				:draw_value(draw_value_) {}
 			constexpr explicit RectBaseWithValue(const ::dtl::base::MatrixRange & matrix_range_) noexcept

--- a/include/DTL/Utility/ReplaceAll.hpp
+++ b/include/DTL/Utility/ReplaceAll.hpp
@@ -439,7 +439,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr ReplaceAll() noexcept = default;
+			constexpr ReplaceAll() = default;
 			constexpr explicit ReplaceAll(const Matrix_Int_ & after_value_) noexcept
 				:after_value(after_value_) {}
 			template<typename ...Args_>

--- a/include/DTL/Utility/ReplaceSome.hpp
+++ b/include/DTL/Utility/ReplaceSome.hpp
@@ -573,7 +573,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr ReplaceSome() noexcept = default;
+			constexpr ReplaceSome() = default;
 			constexpr explicit ReplaceSome(const ::dtl::type::size replace_num_) noexcept
 				:replace_num(replace_num_) {}
 			constexpr explicit ReplaceSome(const ::dtl::type::size replace_num_, const Matrix_Int_& after_value) noexcept

--- a/include/DTL/Utility/VoronoiDiagram.hpp
+++ b/include/DTL/Utility/VoronoiDiagram.hpp
@@ -382,7 +382,7 @@ namespace dtl {
 
 			///// コンストラクタ /////
 
-			constexpr VoronoiDiagram() noexcept = default;
+			constexpr VoronoiDiagram() = default;
 			constexpr explicit VoronoiDiagram(const ::dtl::type::size draw_value_) noexcept
 				:draw_value(draw_value_) {}
 			constexpr explicit VoronoiDiagram(const ::dtl::base::MatrixRange& matrix_range_) noexcept

--- a/include/DTL/Workaround/cstdioGets.hpp
+++ b/include/DTL/Workaround/cstdioGets.hpp
@@ -1,1 +1,1 @@
-﻿char *gets(char *s);
+﻿extern "C" char *gets(char *s);

--- a/include/DTL/Workaround/cstdioGets.hpp
+++ b/include/DTL/Workaround/cstdioGets.hpp
@@ -1,0 +1,1 @@
+﻿char *gets(char *s);


### PR DESCRIPTION
# 注意

**最強に汚いWorkaroundが含まれています。メンテナンス性を十分に検討してからmergeしてください**

手元のCentOS7環境ではこのWorkaroundなしでは

```
/usr/bin/../lib/gcc/x86_64-redhat-linux/4.8.5/../../../../include/c++/4.8.5/cstdio:120:11: error: no member named 'gets' in the global namespace
  using ::gets;
        ~~^
```

のようなエラーが出ていました。これは極めて危険でC11で削除された`gets`関数を参照しているために発生しているものです。

この問題を解決する正攻法は
[[Clang][C++14][Linux] Clangで標準ライブラリのヘッダでコンパイルエラーが出る場合の対処法 - Qiita](https://qiita.com/koara-local/items/793efec70ddf4e18151c)
にあるように、libc++を使うか
[c++ - clang seems to use the gcc libraries - Stack Overflow](https://stackoverflow.com/questions/24342312/clang-seems-to-use-the-gcc-libraries#comment83445109_48229033)
GCC4.9.2以降付属のlibstdc++を使うことです。
が、これは管理者権限のないユーザーには、gccを一からビルドすることを要求することになるので、気軽に勧められません。
(というか私の環境だとそんなにストレージに空きがない
ref: https://yumetodo.hateblo.jp/entry/2017/07/01/123416

そこで登場したのがこの汚いworkaroundです。必要なのは`gets`の定義ではなく宣言のみであることを利用し

```cpp
extern "C" char *gets(char *s);
```

を予め宣言することで回避します。

このworkaroundは`cstdio`を読み込むより前に読み込む必要があり、`cstdio`は`string`やストリーム系ヘッダ(もっとも基底の`ios`やその派生クラスのある`fstream`/`iostream`/`sstream`ヘッダーなど)なんかで読み込まれています。つまり大抵のファイルの先頭でこのworkaroundのあるファイルをincludeする必要があります。

これは言うまでもなくメンテナンス性を下げるworkaroundです。

採用しない場合は 42c55b7 8ec5dc3 を除外してrebaseする必要があります。

# 概要

```
$cat /etc/centos-release
CentOS Linux release 7.6.1810 (Core)
$gcc -v
組み込み spec を使用しています。
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-redhat-linux/4.8.5/lto-wrapper
ターゲット: x86_64-redhat-linux
configure 設定: ../configure --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-bootstrap --enable-shared --enable-threads=posix --enable-checking=release --with-system-zlib --enable-__cxa_atexit --d
isable-libunwind-exceptions --enable-gnu-unique-object --enable-linker-build-id --with-linker-hash-style=gnu --enable-languages=c,c++,objc,obj-c++,java,fortran,ada,go,lto --enable-plugin --enable-initfini-array --disable-libgcj --with-isl=/builddir/build/BUILD/gcc-4.8.5-20150702/obj-x86_64-redhat-linux/isl-install --with-cloog=/builddir/build/BUILD/gcc-4.8.5-20150702/obj-x86_64-redhat-linux/cloog-install --enable-gnu-indirect-function --with-tune=generic --with-arch_32=x86-64 --build=x86_64-redhat-linux
スレッドモデル: posix
gcc バージョン 4.8.5 20150623 (Red Hat 4.8.5-36) (GCC)
$clang -v
clang version 3.4.2 (tags/RELEASE_34/dot2-final)
Target: x86_64-redhat-linux-gnu
Thread model: posix
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-redhat-linux/4.8.2
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-redhat-linux/4.8.5
Found candidate GCC installation: /usr/lib/gcc/x86_64-redhat-linux/4.8.2
Found candidate GCC installation: /usr/lib/gcc/x86_64-redhat-linux/4.8.5
Selected GCC installation: /usr/bin/../lib/gcc/x86_64-redhat-linux/4.8.5
```

な環境でビルドが通るように。

# お知らせ

```cpp
class foo{
    constexpr foo() noexcept = default;
};
```

のような定義が大量にありましたが、**この`noexcept`はつけてはいけません**

というか

>exception specification of explicitly defaulted move constructor does not match the calculated one

のように言われます。説明が面倒くさくなったので
https://github.com/mapnik/mapnik/issues/3274
に丸投げしますが、そういうことです。