### PR TITLE
Matrix に使用できるコンテナの確認を行いました。

### DIFF
--- a/include/DTL/Shape/Border.hpp
+++ b/include/DTL/Shape/Border.hpp
@@ -16,11 +16,12 @@
 #######################################################################################*/
 
 #include <DTL/Base/Struct.hpp>
-#include <DTL/Macros/nodiscard.hpp>
 #include <DTL/Macros/constexpr.hpp>
+#include <DTL/Macros/nodiscard.hpp>
 #include <DTL/Type/Forward.hpp>
 #include <DTL/Type/SizeT.hpp>
 #include <DTL/Range/RectBaseWithValue.hpp>
+#include <DTL/Utility/DrawJagged.hpp>
 
 /*#######################################################################################
 	[概要] "dtl名前空間"とは"DungeonTemplateLibrary"の全ての機能が含まれる名前空間である。
@@ -33,49 +34,18 @@ namespace dtl {
 	[概要] Borderとは "Matrixの描画範囲の周囲1マスに描画値を設置する" 機能を持つクラスである。
 #######################################################################################*/
 		template<typename Matrix_Int_>
-		class Border : public ::dtl::range::RectBaseWithValue< ::dtl::shape::Border<Matrix_Int_>, Matrix_Int_> {
+		class Border : public ::dtl::range::RectBaseWithValue<Border<Matrix_Int_>, Matrix_Int_>,
+		               public ::dtl::utility::DrawJagged<Border<Matrix_Int_>, Matrix_Int_> {
 		private:
 
 
 			///// エイリアス /////
 
 			using Index_Size = ::dtl::type::size;
-			using ShapeBase_t = ::dtl::range::RectBaseWithValue< ::dtl::shape::Border<Matrix_Int_>, Matrix_Int_>;
+			using ShapeBase_t = ::dtl::range::RectBaseWithValue<Border<Matrix_Int_>, Matrix_Int_>;
+			using DrawBase_t = ::dtl::utility::DrawJagged<Border<Matrix_Int_>, Matrix_Int_>;
 
-
-			///// 代入処理 /////
-
-			template<typename Matrix_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignSTL(Matrix_&& matrix_, const Index_Size end_x_, const Index_Size end_y_) const noexcept {
-				matrix_[end_y_][end_x_] = this->draw_value;
-			}
-			template<typename Matrix_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignArray(Matrix_&& matrix_, const Index_Size end_x_, const Index_Size end_y_, const Index_Size max_x_) const noexcept {
-				matrix_[end_y_ * max_x_ + end_x_] = this->draw_value;
-			}
-			template<typename Matrix_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignLayer(Matrix_&& matrix_, const Index_Size layer_, const Index_Size end_x_, const Index_Size end_y_) const noexcept {
-				matrix_[end_y_][end_x_][layer_] = this->draw_value;
-			}
-
-			template<typename Matrix_, typename Function_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignSTL(Matrix_&& matrix_, const Index_Size end_x_, const Index_Size end_y_, Function_&& function_) const noexcept {
-				if (function_(matrix_[end_y_][end_x_])) matrix_[end_y_][end_x_] = this->draw_value;
-			}
-			template<typename Matrix_, typename Function_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignArray(Matrix_&& matrix_, const Index_Size end_x_, const Index_Size end_y_, const Index_Size max_x_, Function_&& function_) const noexcept {
-				if (function_(matrix_[end_y_ * max_x_ + end_x_])) matrix_[end_y_ * max_x_ + end_x_] = this->draw_value;
-			}
-			template<typename Matrix_, typename Function_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignLayer(Matrix_ && matrix_, const Index_Size layer_, const Index_Size end_x_, const Index_Size end_y_, Function_ && function_) const noexcept {
-				if (function_(matrix_[end_y_][end_x_][layer_])) matrix_[end_y_][end_x_][layer_] = this->draw_value;
-			}
+			friend DrawBase_t;
 
 
 			///// 基本処理 /////
@@ -83,67 +53,21 @@ namespace dtl {
 			//STL
 			template<typename Matrix_, typename ...Args_>
 			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawSTL(Matrix_ && matrix_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				if (end_y_ == 0) return true;
-				for (Index_Size col{ this->start_x }; col < matrix_[this->start_y].size(); ++col)
-					this->assignSTL(matrix_, col, this->start_y, args_...);
-				for (Index_Size col{ this->start_x }; col < matrix_[end_y_ - 1].size(); ++col)
-					this->assignSTL(matrix_, col, end_y_ - 1, args_...);
+				typename std::enable_if<Matrix_::is_jagged::value, bool>::type
+				drawNormal(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
+				const Index_Size end_y_ = this->calcEndY(matrix_.getY());
+				if (end_y_ <= this->start_y) return true;
+				const Index_Size last_x1 = this->calcEndX(matrix_.getX(this->start_y));
+				for (Index_Size col{ this->start_x }; col < last_x1; ++col)
+					matrix_.set(col, this->start_y, this->draw_value, args_...);
+				const Index_Size last_x2 = this->calcEndX(matrix_.getX(end_y_ - 1));
+				for (Index_Size col{ this->start_x }; col < last_x2; ++col)
+					matrix_.set(col, end_y_ - 1, this->draw_value, args_...);
 				for (Index_Size row{ this->start_y }; row < end_y_; ++row) {
-					if (matrix_[row].size() == 0) continue;
-					this->assignSTL(matrix_, this->start_x, row, args_...);
-					this->assignSTL(matrix_, matrix_[row].size() - 1, row, DTL_TYPE_FORWARD<Args_>(args_)...);
-				}
-				return true;
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawWidthSTL(Matrix_ && matrix_, const Index_Size end_x_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				if (end_y_ == 0) return true;
-				for (Index_Size col{ this->start_x }; col < end_x_ && col < matrix_[this->start_y].size(); ++col)
-					this->assignSTL(matrix_, col, this->start_y, args_...);
-				for (Index_Size col{ this->start_x }; col < end_x_ && col < matrix_[end_y_ - 1].size(); ++col)
-					this->assignSTL(matrix_, col, end_y_ - 1, args_...);
-				if (end_x_ == 0) return true;
-				for (Index_Size row{ this->start_y }; row < end_y_; ++row) {
-					if (matrix_[row].size() == 0) continue;
-					this->assignSTL(matrix_, this->start_x, row, args_...);
-					if (matrix_[row].size() <= end_x_) this->assignSTL(matrix_, matrix_[row].size() - 1, row, args_...);
-					else this->assignSTL(matrix_, end_x_ - 1, row, DTL_TYPE_FORWARD<Args_>(args_)...);
-				}
-				return true;
-			}
-
-			//LayerSTL
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawLayerSTL(Matrix_ && matrix_, const Index_Size layer_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				if (end_y_ == 0) return true;
-				for (Index_Size col{ this->start_x }; col < matrix_[this->start_y].size(); ++col)
-					this->assignLayer(matrix_, layer_, col, this->start_y, args_...);
-				for (Index_Size col{ this->start_x }; col < matrix_[end_y_ - 1].size(); ++col)
-					this->assignLayer(matrix_, layer_, col, end_y_ - 1, args_...);
-				for (Index_Size row{ this->start_y }; row < end_y_; ++row) {
-					if (matrix_[row].size() == 0) continue;
-					this->assignLayer(matrix_, layer_, this->start_x, row, args_...);
-					this->assignLayer(matrix_, layer_, matrix_[row].size() - 1, row, DTL_TYPE_FORWARD<Args_>(args_)...);
-				}
-				return true;
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawLayerWidthSTL(Matrix_ && matrix_, const Index_Size layer_, const Index_Size end_x_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				if (end_y_ == 0) return true;
-				for (Index_Size col{ this->start_x }; col < end_x_ && col < matrix_[this->start_y].size(); ++col)
-					this->assignLayer(matrix_, layer_, col, this->start_y, args_...);
-				for (Index_Size col{ this->start_x }; col < end_x_ && col < matrix_[end_y_ - 1].size(); ++col)
-					this->assignLayer(matrix_, layer_, col, end_y_ - 1, args_...);
-				if (end_x_ == 0) return true;
-				for (Index_Size row{ this->start_y }; row < end_y_; ++row) {
-					if (matrix_[row].size() == 0) continue;
-					this->assignLayer(matrix_, layer_, this->start_x, row, args_...);
-					if (matrix_[row].size() <= end_x_) this->assignLayer(matrix_, layer_, matrix_[row].size() - 1, row, args_...);
-					else this->assignLayer(matrix_, layer_, end_x_ - 1, row, DTL_TYPE_FORWARD<Args_>(args_)...);
+					const Index_Size last_x3 = this->calcEndX(matrix_.getX(row));
+					if (last_x3 <= this->start_x) continue;
+					matrix_.set(this->start_x, row, this->draw_value, args_...);
+					matrix_.set(last_x3 - 1, row, this->draw_value, args_...);
 				}
 				return true;
 			}
@@ -151,141 +75,24 @@ namespace dtl {
 			//Normal
 			template<typename Matrix_, typename ...Args_>
 			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawNormal(Matrix_ && matrix_, const Index_Size end_x_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				if (end_x_ == 0 || end_y_ == 0) return true;
+				typename std::enable_if<!Matrix_::is_jagged::value, bool>::type
+				drawNormal(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
+				const Index_Size end_x_ = this->calcEndX(matrix_.getX());
+				const Index_Size end_y_ = this->calcEndY(matrix_.getY());
+				if (end_x_ <= this->start_x || end_y_ <= this->start_y) return true;
 				for (Index_Size col{ this->start_x }; col < end_x_; ++col) {
-					this->assignSTL(matrix_, col, this->start_y, args_...);
-					this->assignSTL(matrix_, col, end_y_ - 1, args_...);
+					matrix_.set(col, this->start_y, this->draw_value, args_...);
+					matrix_.set(col, end_y_ - 1, this->draw_value, args_...);
 				}
 				for (Index_Size row{ this->start_y }; row < end_y_; ++row) {
-					this->assignSTL(matrix_, this->start_x, row, args_...);
-					this->assignSTL(matrix_, end_x_ - 1, row, DTL_TYPE_FORWARD<Args_>(args_)...);
-				}
-				return true;
-			}
-
-			//LayerNormal
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawLayerNormal(Matrix_ && matrix_, const Index_Size layer_, const Index_Size end_x_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				if (end_x_ == 0 || end_y_ == 0) return true;
-				for (Index_Size col{ this->start_x }; col < end_x_; ++col) {
-					this->assignLayer(matrix_, layer_, col, this->start_y, args_...);
-					this->assignLayer(matrix_, layer_, col, end_y_ - 1, args_...);
-				}
-				for (Index_Size row{ this->start_y }; row < end_y_; ++row) {
-					this->assignLayer(matrix_, layer_, this->start_x, row, args_...);
-					this->assignLayer(matrix_, layer_, end_x_ - 1, row, DTL_TYPE_FORWARD<Args_>(args_)...);
-				}
-				return true;
-			}
-
-			//Array
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawArray(Matrix_ && matrix_, const Index_Size end_x_, const Index_Size end_y_, const Index_Size max_x_, Args_ && ... args_) const noexcept {
-				if (end_x_ == 0 || end_y_ == 0) return true;
-				for (Index_Size col{ this->start_x }; col < end_x_; ++col) {
-					this->assignArray(matrix_, col, this->start_y, max_x_, args_...);
-					this->assignArray(matrix_, col, end_y_ - 1, max_x_, args_...);
-				}
-				for (Index_Size row{ this->start_y }; row < end_y_; ++row) {
-					this->assignArray(matrix_, this->start_x, row, max_x_, args_...);
-					this->assignArray(matrix_, end_x_ - 1, row, max_x_, DTL_TYPE_FORWARD<Args_>(args_)...);
+					matrix_.set(this->start_x, row, this->draw_value, args_...);
+					matrix_.set(end_x_ - 1, row, this->draw_value, args_...);
 				}
 				return true;
 			}
 
 		public:
 
-
-			///// 生成呼び出し /////
-
-			//STL
-			template<typename Matrix_>
-			constexpr bool draw(Matrix_ && matrix_) const noexcept {
-				return (this->width == 0) ? this->drawSTL(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndY(matrix_.size())) : this->drawWidthSTL(matrix_, this->start_x + this->width, this->calcEndY(matrix_.size()));
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperator(Matrix_ && matrix_, Function_ && function_) const noexcept {
-				return (this->width == 0) ? this->drawSTL(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndY(matrix_.size()), function_) : this->drawWidthSTL(matrix_, this->start_x + this->width, this->calcEndY(matrix_.size()), function_);
-			}
-
-			//LayerSTL
-			template<typename Matrix_>
-			constexpr bool draw(Matrix_ && matrix_, const Index_Size layer_) const noexcept {
-				return (this->width == 0) ? this->drawLayerSTL(DTL_TYPE_FORWARD<Matrix_>(matrix_), layer_, this->calcEndY(matrix_.size())) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, this->calcEndY(matrix_.size()));
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size layer_, Function_ && function_) const noexcept {
-				return (this->width == 0) ? this->drawLayerSTL(DTL_TYPE_FORWARD<Matrix_>(matrix_), layer_, this->calcEndY(matrix_.size()), function_) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, this->calcEndY(matrix_.size()), function_);
-			}
-
-			//Normal
-			template<typename Matrix_>
-			constexpr bool draw(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawNormal(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_));
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawNormal(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), function_);
-			}
-
-			//LayerNormal
-			template<typename Matrix_>
-			constexpr bool draw(Matrix_ && matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawLayerNormal(DTL_TYPE_FORWARD<Matrix_>(matrix_), layer_, this->calcEndX(max_x_), this->calcEndY(max_y_));
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawLayerNormal(DTL_TYPE_FORWARD<Matrix_>(matrix_), layer_, this->calcEndX(max_x_), this->calcEndY(max_y_), function_);
-			}
-
-			//Array
-			template<typename Matrix_>
-			constexpr bool drawArray(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawArray(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), max_x_);
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperatorArray(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawArray(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), max_x_, function_);
-			}
-
-
-			///// 生成呼び出しファンクタ /////
-
-			template<typename Matrix_, typename ...Args_>
-			constexpr bool operator()(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				return this->draw(DTL_TYPE_FORWARD<Matrix_>(matrix_), DTL_TYPE_FORWARD<Args_>(args_)...);
-			}
-
-
-			///// ダンジョン行列生成 /////
-
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				Matrix_&& create(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				this->draw(matrix_, DTL_TYPE_FORWARD<Args_>(args_)...);
-				return DTL_TYPE_FORWARD<Matrix_>(matrix_);
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				Matrix_&& createArray(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				this->drawArray(matrix_, DTL_TYPE_FORWARD<Args_>(args_)...);
-				return DTL_TYPE_FORWARD<Matrix_>(matrix_);
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				Matrix_&& createOperator(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				this->drawOperator(matrix_, DTL_TYPE_FORWARD<Args_>(args_)...);
-				return DTL_TYPE_FORWARD<Matrix_>(matrix_);
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				Matrix_&& createOperatorArray(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				this->drawOperatorArray(matrix_, DTL_TYPE_FORWARD<Args_>(args_)...);
-				return DTL_TYPE_FORWARD<Matrix_>(matrix_);
-			}
 
 			///// コンストラクタ /////
 

--- a/include/DTL/Shape/BorderOdd.hpp
+++ b/include/DTL/Shape/BorderOdd.hpp
@@ -16,11 +16,12 @@
 #######################################################################################*/
 
 #include <DTL/Base/Struct.hpp>
-#include <DTL/Macros/nodiscard.hpp>
 #include <DTL/Macros/constexpr.hpp>
+#include <DTL/Macros/nodiscard.hpp>
 #include <DTL/Type/Forward.hpp>
 #include <DTL/Type/SizeT.hpp>
 #include <DTL/Range/RectBaseWithValue.hpp>
+#include <DTL/Utility/DrawJagged.hpp>
 
 /*#######################################################################################
 	[概要] "dtl名前空間"とは"DungeonTemplateLibrary"の全ての機能が含まれる名前空間である。
@@ -34,49 +35,18 @@ namespace dtl {
 			行数が偶数の時[行数-2行目]のマスに描画値を設置する(※行/列は0から数える)" 機能を持つクラスである。
 #######################################################################################*/
 		template<typename Matrix_Int_>
-		class BorderOdd : public ::dtl::range::RectBaseWithValue< ::dtl::shape::BorderOdd<Matrix_Int_>, Matrix_Int_> {
+		class BorderOdd : public ::dtl::range::RectBaseWithValue<BorderOdd<Matrix_Int_>, Matrix_Int_>,
+		                  public ::dtl::utility::DrawJagged<BorderOdd<Matrix_Int_>, Matrix_Int_> {
 		private:
 
 
 			///// エイリアス /////
 
 			using Index_Size = ::dtl::type::size;
-			using ShapeBase_t = ::dtl::range::RectBaseWithValue< ::dtl::shape::BorderOdd<Matrix_Int_>, Matrix_Int_>;
+			using ShapeBase_t = ::dtl::range::RectBaseWithValue<BorderOdd<Matrix_Int_>, Matrix_Int_>;
+			using DrawBase_t = ::dtl::utility::DrawJagged<BorderOdd<Matrix_Int_>, Matrix_Int_>;
 
-
-			///// 代入処理 /////
-
-			template<typename Matrix_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignSTL(Matrix_&& matrix_, const Index_Size end_x_, const Index_Size end_y_) const noexcept {
-				matrix_[end_y_][end_x_] = this->draw_value;
-			}
-			template<typename Matrix_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignArray(Matrix_&& matrix_, const Index_Size end_x_, const Index_Size end_y_, const Index_Size max_x_) const noexcept {
-				matrix_[end_y_ * max_x_ + end_x_] = this->draw_value;
-			}
-			template<typename Matrix_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignLayer(Matrix_&& matrix_, const Index_Size layer_, const Index_Size end_x_, const Index_Size end_y_) const noexcept {
-				matrix_[end_y_][end_x_][layer_] = this->draw_value;
-			}
-
-			template<typename Matrix_, typename Function_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignSTL(Matrix_&& matrix_, const Index_Size end_x_, const Index_Size end_y_, Function_&& function_) const noexcept {
-				if (function_(matrix_[end_y_][end_x_])) matrix_[end_y_][end_x_] = this->draw_value;
-			}
-			template<typename Matrix_, typename Function_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignArray(Matrix_&& matrix_, const Index_Size end_x_, const Index_Size end_y_, const Index_Size max_x_, Function_&& function_) const noexcept {
-				if (function_(matrix_[end_y_ * max_x_ + end_x_])) matrix_[end_y_ * max_x_ + end_x_] = this->draw_value;
-			}
-			template<typename Matrix_, typename Function_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignLayer(Matrix_ && matrix_, const Index_Size layer_, const Index_Size end_x_, const Index_Size end_y_, Function_ && function_) const noexcept {
-				if (function_(matrix_[end_y_][end_x_][layer_])) matrix_[end_y_][end_x_][layer_] = this->draw_value;
-			}
+			friend DrawBase_t;
 
 
 			///// 基本処理 /////
@@ -84,89 +54,24 @@ namespace dtl {
 			//STL
 			template<typename Matrix_, typename ...Args_>
 			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawSTL(Matrix_ && matrix_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				if (end_y_ == 0) return true;
-				for (Index_Size col{ this->start_x }; col < matrix_[this->start_y].size(); ++col)
-					this->assignSTL(matrix_, col, this->start_y, args_...);
-				for (Index_Size col{ this->start_x }; col < matrix_[end_y_ - 1].size(); ++col) {
-					if ((end_y_ - this->start_y) % 2 == 0) this->assignSTL(matrix_, col, end_y_ - 2, args_...);
-					this->assignSTL(matrix_, col, end_y_ - 1, args_...);
+				typename std::enable_if<Matrix_::is_jagged::value, bool>::type
+				drawNormal(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
+				const Index_Size end_y_ = this->calcEndY(matrix_.getY());
+				if (end_y_ <= this->start_y) return true;
+				const Index_Size last_x1 = this->calcEndX(matrix_.getX(this->start_y));
+				for (Index_Size col{ this->start_x }; col < last_x1; ++col)
+					matrix_.set(col, this->start_y, this->draw_value, args_...);
+				const Index_Size last_x2 = this->calcEndX(matrix_.getX(end_y_ - 1));
+				for (Index_Size col{ this->start_x }; col < last_x2; ++col) {
+					if ((end_y_ - this->start_y) % 2 == 0) matrix_.set(col, end_y_ - 2, this->draw_value, args_...);
+					matrix_.set(col, end_y_ - 1, this->draw_value, args_...);
 				}
 				for (Index_Size row{ this->start_y }; row < end_y_; ++row) {
-					if (matrix_[row].size() == 0) continue;
-					this->assignSTL(matrix_, this->start_x, row, args_...);
-					if ((matrix_[row].size() - this->start_x) % 2 == 0) this->assignSTL(matrix_, matrix_[row].size() - 2, row, args_...);
-					this->assignSTL(matrix_, matrix_[row].size() - 1, row, DTL_TYPE_FORWARD<Args_>(args_)...);
-				}
-				return true;
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawWidthSTL(Matrix_ && matrix_, const Index_Size end_x_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				if (end_y_ < 2) return true;
-				for (Index_Size col{ this->start_x }; col < end_x_ && col < matrix_[this->start_y].size(); ++col)
-					this->assignSTL(matrix_, col, this->start_y, args_...);
-				for (Index_Size col{ this->start_x }; col < end_x_ && col < matrix_[end_y_ - 1].size(); ++col) {
-					if ((end_y_ - this->start_y) % 2 == 0) this->assignSTL(matrix_, col, end_y_ - 2, args_...);
-					this->assignSTL(matrix_, col, end_y_ - 1, args_...);
-				}
-				if (end_x_ < 2) return true;
-				for (Index_Size row{ this->start_y }; row < end_y_; ++row) {
-					if (matrix_[row].size() == 0) continue;
-					this->assignSTL(matrix_, this->start_x, row, args_...);
-					if (matrix_[row].size() <= end_x_) {
-						if ((matrix_[row].size() - this->start_x) % 2 == 0) this->assignSTL(matrix_, matrix_[row].size() - 2, row, args_...);
-						this->assignSTL(matrix_, matrix_[row].size() - 1, row, args_...);
-					}
-					else {
-						if ((end_x_ - this->start_x) % 2 == 0) this->assignSTL(matrix_, end_x_ - 2, row, args_...);
-						this->assignSTL(matrix_, end_x_ - 1, row, DTL_TYPE_FORWARD<Args_>(args_)...);
-					}
-				}
-				return true;
-			}
-
-			//LayerSTL
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawLayerSTL(Matrix_ && matrix_, const Index_Size layer_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				if (end_y_ < 2) return true;
-				for (Index_Size col{ this->start_x }; col < matrix_[this->start_y].size(); ++col)
-					this->assignLayer(matrix_, layer_, col, this->start_y, args_...);
-				for (Index_Size col{ this->start_x }; col < matrix_[end_y_ - 1].size(); ++col) {
-					if ((end_y_ - this->start_y) % 2 == 0) this->assignLayer(matrix_, layer_, col, end_y_ - 2, args_...);
-					this->assignLayer(matrix_, layer_, col, end_y_ - 1, args_...);
-				}
-				for (Index_Size row{ this->start_y }; row < end_y_; ++row) {
-					if (matrix_[row].size() < 2) continue;
-					this->assignLayer(matrix_, layer_, this->start_x, row, args_...);
-					if ((matrix_[row].size() - this->start_x) % 2 == 0) this->assignLayer(matrix_, layer_, matrix_[row].size() - 2, row, args_...);
-					this->assignLayer(matrix_, layer_, matrix_[row].size() - 1, row, DTL_TYPE_FORWARD<Args_>(args_)...);
-				}
-				return true;
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawLayerWidthSTL(Matrix_ && matrix_, const Index_Size layer_, const Index_Size end_x_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				if (end_y_ < 2) return true;
-				for (Index_Size col{ this->start_x }; col < end_x_ && col < matrix_[this->start_y].size(); ++col)
-					this->assignLayer(matrix_, layer_, col, this->start_y, args_...);
-				for (Index_Size col{ this->start_x }; col < end_x_ && col < matrix_[end_y_ - 1].size(); ++col) {
-					if ((end_y_ - this->start_y) % 2 == 0) this->assignLayer(matrix_, layer_, col, end_y_ - 2, args_...);
-					this->assignLayer(matrix_, layer_, col, end_y_ - 1, args_...);
-				}
-				if (end_x_ < 2) return true;
-				for (Index_Size row{ this->start_y }; row < end_y_; ++row) {
-					if (matrix_[row].size() == 0) continue;
-					this->assignLayer(matrix_, layer_, this->start_x, row, args_...);
-					if (matrix_[row].size() <= end_x_) {
-						if ((matrix_[row].size() - this->start_x) % 2 == 0) this->assignLayer(matrix_, layer_, matrix_[row].size() - 2, row, args_...);
-						this->assignLayer(matrix_, layer_, matrix_[row].size() - 1, row, args_...);
-					}
-					else {
-						if ((end_x_ - this->start_x) % 2 == 0) this->assignLayer(matrix_, layer_, end_x_ - 2, row, args_...);
-						this->assignLayer(matrix_, layer_, end_x_ - 1, row, DTL_TYPE_FORWARD<Args_>(args_)...);
-					}
+					const Index_Size last_x3 = this->calcEndX(matrix_.getX(row));
+					if (last_x3 <= this->start_x) continue;
+					matrix_.set(this->start_x, row, this->draw_value, args_...);
+					if ((last_x3 - this->start_x) % 2 == 0) matrix_.set(last_x3 - 2, row, this->draw_value, args_...);
+					matrix_.set(last_x3 - 1, row, this->draw_value, args_...);
 				}
 				return true;
 			}
@@ -174,147 +79,26 @@ namespace dtl {
 			//Normal
 			template<typename Matrix_, typename ...Args_>
 			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawNormal(Matrix_ && matrix_, const Index_Size end_x_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				if (end_x_ < 2 || end_y_ < 2) return true;
+				typename std::enable_if<!Matrix_::is_jagged::value, bool>::type
+				drawNormal(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
+				const Index_Size end_x_ = this->calcEndX(matrix_.getX());
+				const Index_Size end_y_ = this->calcEndY(matrix_.getY());
+				if (end_x_ <= this->start_x || end_y_ <= this->start_y) return true;
 				for (Index_Size col{ this->start_x }; col < end_x_; ++col) {
-					this->assignSTL(matrix_, col, this->start_y, args_...);
-					if ((end_y_ - this->start_y) % 2 == 0) this->assignSTL(matrix_, col, end_y_ - 2, args_...);
-					this->assignSTL(matrix_, col, end_y_ - 1, args_...);
+					matrix_.set(col, this->start_y, this->draw_value, args_...);
+					if ((end_y_ - this->start_y) % 2 == 0) matrix_.set(col, end_y_ - 2, this->draw_value, args_...);
+					matrix_.set(col, end_y_ - 1, this->draw_value, args_...);
 				}
 				for (Index_Size row{ this->start_y }; row < end_y_; ++row) {
-					this->assignSTL(matrix_, this->start_x, row, args_...);
-					if ((end_x_ - this->start_x) % 2 == 0) this->assignSTL(matrix_, end_x_ - 2, row, args_...);
-					this->assignSTL(matrix_, end_x_ - 1, row, DTL_TYPE_FORWARD<Args_>(args_)...);
-				}
-				return true;
-			}
-
-			//LayerNormal
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawLayerNormal(Matrix_ && matrix_, const Index_Size layer_, const Index_Size end_x_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				if (end_x_ < 2 || end_y_ < 2) return true;
-				for (Index_Size col{ this->start_x }; col < end_x_; ++col) {
-					this->assignLayer(matrix_, layer_, col, this->start_y, args_...);
-					if ((end_y_ - this->start_y) % 2 == 0) this->assignLayer(matrix_, layer_, col, end_y_ - 2, args_...);
-					this->assignLayer(matrix_, layer_, col, end_y_ - 1, args_...);
-				}
-				for (Index_Size row{ this->start_y }; row < end_y_; ++row) {
-					this->assignLayer(matrix_, layer_, this->start_x, row, args_...);
-					if ((end_y_ - this->start_y) % 2 == 0) this->assignLayer(matrix_, layer_, end_x_ - 2, row, args_...);
-					this->assignLayer(matrix_, layer_, end_x_ - 1, row, DTL_TYPE_FORWARD<Args_>(args_)...);
-				}
-				return true;
-			}
-
-			//Array
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawArray(Matrix_ && matrix_, const Index_Size end_x_, const Index_Size end_y_, const Index_Size max_x_, Args_ && ... args_) const noexcept {
-				if (end_x_ < 2 || end_y_ < 2) return true;
-				for (Index_Size col{ this->start_x }; col < end_x_; ++col) {
-					this->assignArray(matrix_, col, this->start_y, max_x_, args_...);
-					if ((end_y_ - this->start_y) % 2 == 0) this->assignArray(matrix_, col, end_y_ - 2, max_x_, args_...);
-					this->assignArray(matrix_, col, end_y_ - 1, max_x_, args_...);
-				}
-				for (Index_Size row{ this->start_y }; row < end_y_; ++row) {
-					this->assignArray(matrix_, this->start_x, row, max_x_, args_...);
-					if ((end_y_ - this->start_y) % 2 == 0) this->assignArray(matrix_, end_x_ - 2, row, max_x_, args_...);
-					this->assignArray(matrix_, end_x_ - 1, row, max_x_, DTL_TYPE_FORWARD<Args_>(args_)...);
+					matrix_.set(this->start_x, row, this->draw_value, args_...);
+					if ((end_x_ - this->start_x) % 2 == 0) matrix_.set(end_x_ - 2, row, this->draw_value, args_...);
+					matrix_.set(end_x_ - 1, row, this->draw_value, args_...);
 				}
 				return true;
 			}
 
 		public:
 
-
-			///// 生成呼び出し /////
-
-			//STL
-			template<typename Matrix_>
-			constexpr bool draw(Matrix_&& matrix_) const noexcept {
-				return (this->width == 0) ? this->drawSTL(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndY(matrix_.size())) : this->drawWidthSTL(matrix_, this->start_x + this->width, this->calcEndY(matrix_.size()));
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperator(Matrix_ && matrix_, Function_ && function_) const noexcept {
-				return (this->width == 0) ? this->drawSTL(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndY(matrix_.size()), function_) : this->drawWidthSTL(matrix_, this->start_x + this->width, this->calcEndY(matrix_.size()), function_);
-			}
-
-			//LayerSTL
-			template<typename Matrix_>
-			constexpr bool draw(Matrix_ && matrix_, const Index_Size layer_) const noexcept {
-				return (this->width == 0) ? this->drawLayerSTL(DTL_TYPE_FORWARD<Matrix_>(matrix_), layer_, this->calcEndY(matrix_.size())) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, this->calcEndY(matrix_.size()));
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size layer_, Function_ && function_) const noexcept {
-				return (this->width == 0) ? this->drawLayerSTL(DTL_TYPE_FORWARD<Matrix_>(matrix_), layer_, this->calcEndY(matrix_.size()), function_) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, this->calcEndY(matrix_.size()), function_);
-			}
-
-			//Normal
-			template<typename Matrix_>
-			constexpr bool draw(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawNormal(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_));
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawNormal(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), function_);
-			}
-
-			//LayerNormal
-			template<typename Matrix_>
-			constexpr bool draw(Matrix_ && matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawLayerNormal(DTL_TYPE_FORWARD<Matrix_>(matrix_), layer_, this->calcEndX(max_x_), this->calcEndY(max_y_));
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawLayerNormal(DTL_TYPE_FORWARD<Matrix_>(matrix_), layer_, this->calcEndX(max_x_), this->calcEndY(max_y_), function_);
-			}
-
-			//Array
-			template<typename Matrix_>
-			constexpr bool drawArray(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawArray(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), max_x_);
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperatorArray(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawArray(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), max_x_, function_);
-			}
-
-
-			///// 生成呼び出しファンクタ /////
-
-			template<typename Matrix_, typename ...Args_>
-			constexpr bool operator()(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				return this->draw(DTL_TYPE_FORWARD<Matrix_>(matrix_), DTL_TYPE_FORWARD<Args_>(args_)...);
-			}
-
-
-			///// ダンジョン行列生成 /////
-
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				Matrix_&& create(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				this->draw(matrix_, DTL_TYPE_FORWARD<Args_>(args_)...);
-				return DTL_TYPE_FORWARD<Matrix_>(matrix_);
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				Matrix_&& createArray(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				this->drawArray(matrix_, DTL_TYPE_FORWARD<Args_>(args_)...);
-				return DTL_TYPE_FORWARD<Matrix_>(matrix_);
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				Matrix_&& createOperator(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				this->drawOperator(matrix_, DTL_TYPE_FORWARD<Args_>(args_)...);
-				return DTL_TYPE_FORWARD<Matrix_>(matrix_);
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				Matrix_&& createOperatorArray(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				this->drawOperatorArray(matrix_, DTL_TYPE_FORWARD<Args_>(args_)...);
-				return DTL_TYPE_FORWARD<Matrix_>(matrix_);
-			}
 
 			///// コンストラクタ /////
 

--- a/include/DTL/Shape/PointGrid.hpp
+++ b/include/DTL/Shape/PointGrid.hpp
@@ -16,11 +16,12 @@
 #######################################################################################*/
 
 #include <DTL/Base/Struct.hpp>
-#include <DTL/Macros/nodiscard.hpp>
 #include <DTL/Macros/constexpr.hpp>
+#include <DTL/Macros/nodiscard.hpp>
 #include <DTL/Type/Forward.hpp>
 #include <DTL/Type/SizeT.hpp>
 #include <DTL/Range/RectBaseWithValue.hpp>
+#include <DTL/Utility/DrawJagged.hpp>
 
 /*#######################################################################################
 	[概要] "dtl名前空間"とは"DungeonTemplateLibrary"の全ての機能が含まれる名前空間である。
@@ -31,49 +32,18 @@ namespace dtl {
 
 		//偶数マスを指定した数値で埋める
 		template<typename Matrix_Int_>
-		class PointGrid : public ::dtl::range::RectBaseWithValue< ::dtl::shape::PointGrid<Matrix_Int_>, Matrix_Int_> {
+		class PointGrid : public ::dtl::range::RectBaseWithValue<PointGrid<Matrix_Int_>, Matrix_Int_>,
+		                  public ::dtl::utility::DrawJagged<PointGrid<Matrix_Int_>, Matrix_Int_> {
 		private:
 
 
 			///// エイリアス /////
 
 			using Index_Size = ::dtl::type::size;
-			using ShapeBase_t = ::dtl::range::RectBaseWithValue< ::dtl::shape::PointGrid<Matrix_Int_>, Matrix_Int_>;
+			using ShapeBase_t = ::dtl::range::RectBaseWithValue<PointGrid<Matrix_Int_>, Matrix_Int_>;
+			using DrawBase_t = ::dtl::utility::DrawJagged<PointGrid<Matrix_Int_>, Matrix_Int_>;
 
-
-			///// 代入処理 /////
-
-			template<typename Matrix_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignSTL(Matrix_&& matrix_, const Index_Size end_x_, const Index_Size end_y_) const noexcept {
-				matrix_[end_y_][end_x_] = this->draw_value;
-			}
-			template<typename Matrix_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignArray(Matrix_&& matrix_, const Index_Size end_x_, const Index_Size end_y_, const Index_Size max_x_) const noexcept {
-				matrix_[end_y_ * max_x_ + end_x_] = this->draw_value;
-			}
-			template<typename Matrix_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignLayer(Matrix_&& matrix_, const Index_Size layer_, const Index_Size end_x_, const Index_Size end_y_) const noexcept {
-				matrix_[end_y_][end_x_][layer_] = this->draw_value;
-			}
-
-			template<typename Matrix_, typename Function_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignSTL(Matrix_&& matrix_, const Index_Size end_x_, const Index_Size end_y_, Function_&& function_) const noexcept {
-				if (function_(matrix_[end_y_][end_x_])) matrix_[end_y_][end_x_] = this->draw_value;
-			}
-			template<typename Matrix_, typename Function_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignArray(Matrix_&& matrix_, const Index_Size end_x_, const Index_Size end_y_, const Index_Size max_x_, Function_&& function_) const noexcept {
-				if (function_(matrix_[end_y_ * max_x_ + end_x_])) matrix_[end_y_ * max_x_ + end_x_] = this->draw_value;
-			}
-			template<typename Matrix_, typename Function_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignLayer(Matrix_ && matrix_, const Index_Size layer_, const Index_Size end_x_, const Index_Size end_y_, Function_ && function_) const noexcept {
-				if (function_(matrix_[end_y_][end_x_][layer_])) matrix_[end_y_][end_x_][layer_] = this->draw_value;
-			}
+			friend DrawBase_t;
 
 
 			///// 基本処理 /////
@@ -81,159 +51,32 @@ namespace dtl {
 			//STL
 			template<typename Matrix_, typename ...Args_>
 			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawSTL(Matrix_ && matrix_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				for (Index_Size row{ this->start_y }; row < end_y_; row += 2)
-					for (Index_Size col{ this->start_x }; col < matrix_[row].size(); col += 2)
-						this->assignSTL(matrix_, col, row, args_...);
-				return true;
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawWidthSTL(Matrix_ && matrix_, const Index_Size end_x_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				for (Index_Size row{ this->start_y }; row < end_y_; row += 2)
-					for (Index_Size col{ this->start_x }; col < matrix_[row].size() && col < end_x_; col += 2)
-						this->assignSTL(matrix_, col, row, args_...);
-				return true;
-			}
-
-			//LayerSTL
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawLayerSTL(Matrix_ && matrix_, const Index_Size layer_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				for (Index_Size row{ this->start_y }; row < end_y_; row += 2)
-					for (Index_Size col{ this->start_x }; col < matrix_[row].size(); col += 2)
-						this->assignLayer(matrix_, layer_, col, row, args_...);
-				return true;
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawLayerWidthSTL(Matrix_ && matrix_, const Index_Size layer_, const Index_Size end_x_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				for (Index_Size row{ this->start_y }; row < end_y_; row += 2)
-					for (Index_Size col{ this->start_x }; col < matrix_[row].size() && col < end_x_; col += 2)
-						this->assignLayer(matrix_, layer_, col, row, args_...);
+				typename std::enable_if<Matrix_::is_jagged::value, bool>::type
+				drawNormal(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
+				const Index_Size end_y_ = this->calcEndY(matrix_.getY());
+				for (Index_Size row{ this->start_y }; row < end_y_; row += 2) {
+					const Index_Size end_x_ = this->calcEndX(matrix_.getX(row));
+					for (Index_Size col{ this->start_x }; col < end_x_; col += 2)
+						matrix_.set(col, row, this->draw_value, args_...);
+				}
 				return true;
 			}
 
 			//Normal
 			template<typename Matrix_, typename ...Args_>
 			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawNormal(Matrix_ && matrix_, const Index_Size end_x_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
+				typename std::enable_if<!Matrix_::is_jagged::value, bool>::type
+				drawNormal(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
+				const Index_Size end_x_ = this->calcEndX(matrix_.getX());
+				const Index_Size end_y_ = this->calcEndY(matrix_.getY());
 				for (Index_Size row{ this->start_y }; row < end_y_; row += 2)
 					for (Index_Size col{ this->start_x }; col < end_x_; col += 2)
-						this->assignSTL(matrix_, col, row, args_...);
-				return true;
-			}
-
-			//LayerNormal
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawLayerNormal(Matrix_ && matrix_, const Index_Size layer_, const Index_Size end_x_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				for (Index_Size row{ this->start_y }; row < end_y_; row += 2)
-					for (Index_Size col{ this->start_x }; col < end_x_; col += 2)
-						this->assignLayer(matrix_, layer_, col, row, args_...);
-				return true;
-			}
-
-			//Array
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawArray(Matrix_ && matrix_, const Index_Size end_x_, const Index_Size end_y_, const Index_Size max_x_, Args_ && ... args_) const noexcept {
-				for (Index_Size row{ this->start_y }; row < end_y_; row += 2)
-					for (Index_Size col{ this->start_x }; col < end_x_; col += 2)
-						this->assignArray(matrix_, col, row, max_x_, args_...);
+						matrix_.set(col, row, this->draw_value, args_...);
 				return true;
 			}
 
 		public:
 
-
-			///// 生成呼び出し /////
-
-			//STL
-			template<typename Matrix_>
-			constexpr bool draw(Matrix_&& matrix_) const noexcept {
-				return (this->width == 0) ? this->drawSTL(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndY(matrix_.size())) : this->drawWidthSTL(matrix_, this->start_x + this->width, this->calcEndY(matrix_.size()));
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperator(Matrix_ && matrix_, Function_ && function_) const noexcept {
-				return (this->width == 0) ? this->drawSTL(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndY(matrix_.size()), function_) : this->drawWidthSTL(matrix_, this->start_x + this->width, this->calcEndY(matrix_.size()), function_);
-			}
-
-			//LayerSTL
-			template<typename Matrix_>
-			constexpr bool draw(Matrix_ && matrix_, const Index_Size layer_) const noexcept {
-				return (this->width == 0) ? this->drawLayerSTL(DTL_TYPE_FORWARD<Matrix_>(matrix_), layer_, this->calcEndY(matrix_.size())) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, this->calcEndY(matrix_.size()));
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size layer_, Function_ && function_) const noexcept {
-				return (this->width == 0) ? this->drawLayerSTL(DTL_TYPE_FORWARD<Matrix_>(matrix_), layer_, this->calcEndY(matrix_.size()), function_) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, this->calcEndY(matrix_.size()), function_);
-			}
-
-			//Normal
-			template<typename Matrix_>
-			constexpr bool draw(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawNormal(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_));
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawNormal(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), function_);
-			}
-
-			//LayerNormal
-			template<typename Matrix_>
-			constexpr bool draw(Matrix_ && matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawLayerNormal(DTL_TYPE_FORWARD<Matrix_>(matrix_), layer_, this->calcEndX(max_x_), this->calcEndY(max_y_));
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawLayerNormal(DTL_TYPE_FORWARD<Matrix_>(matrix_), layer_, this->calcEndX(max_x_), this->calcEndY(max_y_), function_);
-			}
-
-			//Array
-			template<typename Matrix_>
-			constexpr bool drawArray(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawArray(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), max_x_);
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperatorArray(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawArray(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), max_x_, function_);
-			}
-
-
-			///// 生成呼び出しファンクタ /////
-
-			template<typename Matrix_, typename ...Args_>
-			constexpr bool operator()(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				return this->draw(DTL_TYPE_FORWARD<Matrix_>(matrix_), DTL_TYPE_FORWARD<Args_>(args_)...);
-			}
-
-
-			///// ダンジョン行列生成 /////
-
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				Matrix_&& create(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				this->draw(matrix_, DTL_TYPE_FORWARD<Args_>(args_)...);
-				return DTL_TYPE_FORWARD<Matrix_>(matrix_);
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				Matrix_&& createArray(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				this->drawArray(matrix_, DTL_TYPE_FORWARD<Args_>(args_)...);
-				return DTL_TYPE_FORWARD<Matrix_>(matrix_);
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				Matrix_&& createOperator(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				this->drawOperator(matrix_, DTL_TYPE_FORWARD<Args_>(args_)...);
-				return DTL_TYPE_FORWARD<Matrix_>(matrix_);
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				Matrix_&& createOperatorArray(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				this->drawOperatorArray(matrix_, DTL_TYPE_FORWARD<Args_>(args_)...);
-				return DTL_TYPE_FORWARD<Matrix_>(matrix_);
-			}
 
 			///// コンストラクタ /////
 

--- a/include/DTL/Shape/Rect.hpp
+++ b/include/DTL/Shape/Rect.hpp
@@ -16,11 +16,12 @@
 #######################################################################################*/
 
 #include <DTL/Base/Struct.hpp>
-#include <DTL/Macros/nodiscard.hpp>
 #include <DTL/Macros/constexpr.hpp>
+#include <DTL/Macros/nodiscard.hpp>
 #include <DTL/Type/Forward.hpp>
 #include <DTL/Type/SizeT.hpp>
 #include <DTL/Range/RectBaseWithValue.hpp>
+#include <DTL/Utility/DrawJagged.hpp>
 
 /*#######################################################################################
 	[概要] "dtl名前空間"とは"DungeonTemplateLibrary"の全ての機能が含まれる名前空間である。
@@ -33,49 +34,18 @@ namespace dtl {
 	[概要] Rectとは "Matrixの描画範囲に描画値を設置する" 機能を持つクラスである。
 #######################################################################################*/
 		template<typename Matrix_Int_>
-		class Rect : public ::dtl::range::RectBaseWithValue< ::dtl::shape::Rect<Matrix_Int_>, Matrix_Int_> {
+		class Rect : public ::dtl::range::RectBaseWithValue<Rect<Matrix_Int_>, Matrix_Int_>,
+		             public ::dtl::utility::DrawJagged<Rect<Matrix_Int_>, Matrix_Int_> {
 		private:
 
 
 			///// エイリアス /////
 
 			using Index_Size = ::dtl::type::size;
-			using ShapeBase_t = ::dtl::range::RectBaseWithValue< ::dtl::shape::Rect<Matrix_Int_>, Matrix_Int_>;
+			using ShapeBase_t = ::dtl::range::RectBaseWithValue<Rect<Matrix_Int_>, Matrix_Int_>;
+			using DrawBase_t = ::dtl::utility::DrawJagged<Rect<Matrix_Int_>, Matrix_Int_>;
 
-
-			///// 代入処理 /////
-
-			template<typename Matrix_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignSTL(Matrix_&& matrix_, const Index_Size end_x_, const Index_Size end_y_) const noexcept {
-				matrix_[end_y_][end_x_] = this->draw_value;
-			}
-			template<typename Matrix_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignArray(Matrix_&& matrix_, const Index_Size end_x_, const Index_Size end_y_, const Index_Size max_x_) const noexcept {
-				matrix_[end_y_ * max_x_ + end_x_] = this->draw_value;
-			}
-			template<typename Matrix_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignLayer(Matrix_&& matrix_, const Index_Size layer_, const Index_Size end_x_, const Index_Size end_y_) const noexcept {
-				matrix_[end_y_][end_x_][layer_] = this->draw_value;
-			}
-
-			template<typename Matrix_, typename Function_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignSTL(Matrix_&& matrix_, const Index_Size end_x_, const Index_Size end_y_, Function_&& function_) const noexcept {
-				if (function_(matrix_[end_y_][end_x_])) matrix_[end_y_][end_x_] = this->draw_value;
-			}
-			template<typename Matrix_, typename Function_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignArray(Matrix_&& matrix_, const Index_Size end_x_, const Index_Size end_y_, const Index_Size max_x_, Function_&& function_) const noexcept {
-				if (function_(matrix_[end_y_ * max_x_ + end_x_])) matrix_[end_y_ * max_x_ + end_x_] = this->draw_value;
-			}
-			template<typename Matrix_, typename Function_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				inline void assignLayer(Matrix_ && matrix_, const Index_Size layer_, const Index_Size end_x_, const Index_Size end_y_, Function_ && function_) const noexcept {
-				if (function_(matrix_[end_y_][end_x_][layer_])) matrix_[end_y_][end_x_][layer_] = this->draw_value;
-			}
+			friend DrawBase_t;
 
 
 			///// 基本処理 /////
@@ -83,159 +53,32 @@ namespace dtl {
 			//STL
 			template<typename Matrix_, typename ...Args_>
 			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawSTL(Matrix_ && matrix_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				for (Index_Size row{ this->start_y }; row < end_y_; ++row)
-					for (Index_Size col{ this->start_x }; col < matrix_[row].size(); ++col)
-						this->assignSTL(matrix_, col, row, args_...);
-				return true;
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawWidthSTL(Matrix_ && matrix_, const Index_Size end_x_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				for (Index_Size row{ this->start_y }; row < end_y_; ++row)
-					for (Index_Size col{ this->start_x }; col < matrix_[row].size() && col < end_x_; ++col)
-						this->assignSTL(matrix_, col, row, args_...);
-				return true;
-			}
-
-			//LayerSTL
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawLayerSTL(Matrix_ && matrix_, const Index_Size layer_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				for (Index_Size row{ this->start_y }; row < end_y_; ++row)
-					for (Index_Size col{ this->start_x }; col < matrix_[row].size(); ++col)
-						this->assignLayer(matrix_, layer_, col, row, args_...);
-				return true;
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawLayerWidthSTL(Matrix_ && matrix_, const Index_Size layer_, const Index_Size end_x_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				for (Index_Size row{ this->start_y }; row < end_y_; ++row)
-					for (Index_Size col{ this->start_x }; col < matrix_[row].size() && col < end_x_; ++col)
-						this->assignLayer(matrix_, layer_, col, row, args_...);
+				typename std::enable_if<Matrix_::is_jagged::value, bool>::type
+				drawNormal(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
+				const Index_Size end_y_ = this->calcEndY(matrix_.getY());
+				for (Index_Size row{ this->start_y }; row < end_y_; ++row) {
+					const Index_Size end_x_ = this->calcEndX(matrix_.getX(row));
+					for (Index_Size col{ this->start_x }; col < end_x_; ++col)
+						matrix_.set(col, row, this->draw_value, args_...);
+				}
 				return true;
 			}
 
 			//Normal
 			template<typename Matrix_, typename ...Args_>
 			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawNormal(Matrix_ && matrix_, const Index_Size end_x_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
+				typename std::enable_if<!Matrix_::is_jagged::value, bool>::type
+				drawNormal(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
+				const Index_Size end_x_ = this->calcEndX(matrix_.getX());
+				const Index_Size end_y_ = this->calcEndY(matrix_.getY());
 				for (Index_Size row{ this->start_y }; row < end_y_; ++row)
 					for (Index_Size col{ this->start_x }; col < end_x_; ++col)
-						this->assignSTL(matrix_, col, row, args_...);
-				return true;
-			}
-
-			//LayerNormal
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawLayerNormal(Matrix_ && matrix_, const Index_Size layer_, const Index_Size end_x_, const Index_Size end_y_, Args_ && ... args_) const noexcept {
-				for (Index_Size row{ this->start_y }; row < end_y_; ++row)
-					for (Index_Size col{ this->start_x }; col < end_x_; ++col)
-						this->assignLayer(matrix_, layer_, col, row, args_...);
-				return true;
-			}
-
-			//Array
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				bool drawArray(Matrix_ && matrix_, const Index_Size end_x_, const Index_Size end_y_, const Index_Size max_x_, Args_ && ... args_) const noexcept {
-				for (Index_Size row{ this->start_y }; row < end_y_; ++row)
-					for (Index_Size col{ this->start_x }; col < end_x_; ++col)
-						this->assignArray(matrix_, col, row, max_x_, args_...);
+						matrix_.set(col, row, this->draw_value, args_...);
 				return true;
 			}
 
 		public:
 
-
-			///// 生成呼び出し /////
-
-			//STL
-			template<typename Matrix_>
-			constexpr bool draw(Matrix_&& matrix_) const noexcept {
-				return (this->width == 0) ? this->drawSTL(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndY(matrix_.size())) : this->drawWidthSTL(matrix_, this->start_x + this->width, this->calcEndY(matrix_.size()));
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperator(Matrix_ && matrix_, Function_ && function_) const noexcept {
-				return (this->width == 0) ? this->drawSTL(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndY(matrix_.size()), function_) : this->drawWidthSTL(matrix_, this->start_x + this->width, this->calcEndY(matrix_.size()), function_);
-			}
-
-			//LayerSTL
-			template<typename Matrix_>
-			constexpr bool draw(Matrix_ && matrix_, const Index_Size layer_) const noexcept {
-				return (this->width == 0) ? this->drawLayerSTL(DTL_TYPE_FORWARD<Matrix_>(matrix_), layer_, this->calcEndY(matrix_.size())) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, this->calcEndY(matrix_.size()));
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size layer_, Function_ && function_) const noexcept {
-				return (this->width == 0) ? this->drawLayerSTL(DTL_TYPE_FORWARD<Matrix_>(matrix_), layer_, this->calcEndY(matrix_.size()), function_) : this->drawLayerWidthSTL(matrix_, layer_, this->start_x + this->width, this->calcEndY(matrix_.size()), function_);
-			}
-
-			//Normal
-			template<typename Matrix_>
-			constexpr bool draw(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawNormal(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_));
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawNormal(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), function_);
-			}
-
-			//LayerNormal
-			template<typename Matrix_>
-			constexpr bool draw(Matrix_ && matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawLayerNormal(DTL_TYPE_FORWARD<Matrix_>(matrix_), layer_, this->calcEndX(max_x_), this->calcEndY(max_y_));
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperator(Matrix_ && matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawLayerNormal(DTL_TYPE_FORWARD<Matrix_>(matrix_), layer_, this->calcEndX(max_x_), this->calcEndY(max_y_), function_);
-			}
-
-			//Array
-			template<typename Matrix_>
-			constexpr bool drawArray(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return this->drawArray(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), max_x_);
-			}
-			template<typename Matrix_, typename Function_>
-			constexpr bool drawOperatorArray(Matrix_ && matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return this->drawArray(DTL_TYPE_FORWARD<Matrix_>(matrix_), this->calcEndX(max_x_), this->calcEndY(max_y_), max_x_, function_);
-			}
-
-
-			///// 生成呼び出しファンクタ /////
-
-			template<typename Matrix_, typename ...Args_>
-			constexpr bool operator()(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				return this->draw(DTL_TYPE_FORWARD<Matrix_>(matrix_), DTL_TYPE_FORWARD<Args_>(args_)...);
-			}
-
-
-			///// ダンジョン行列生成 /////
-
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				Matrix_&& create(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				this->draw(matrix_, DTL_TYPE_FORWARD<Args_>(args_)...);
-				return DTL_TYPE_FORWARD<Matrix_>(matrix_);
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				Matrix_&& createArray(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				this->drawArray(matrix_, DTL_TYPE_FORWARD<Args_>(args_)...);
-				return DTL_TYPE_FORWARD<Matrix_>(matrix_);
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				Matrix_&& createOperator(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				this->drawOperator(matrix_, DTL_TYPE_FORWARD<Args_>(args_)...);
-				return DTL_TYPE_FORWARD<Matrix_>(matrix_);
-			}
-			template<typename Matrix_, typename ...Args_>
-			DTL_VERSIONING_CPP14_CONSTEXPR
-				Matrix_&& createOperatorArray(Matrix_ && matrix_, Args_ && ... args_) const noexcept {
-				this->drawOperatorArray(matrix_, DTL_TYPE_FORWARD<Args_>(args_)...);
-				return DTL_TYPE_FORWARD<Matrix_>(matrix_);
-			}
 
 			///// コンストラクタ /////
 

--- a/include/DTL/Utility/DrawJagged.hpp
+++ b/include/DTL/Utility/DrawJagged.hpp
@@ -42,51 +42,51 @@ namespace dtl {
 			//STL
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ & matrix_) const noexcept {
-				return static_cast<const Derived*>(this)->drawNormal(makeWrapper(matrix_));
+				return static_cast<const Derived*>(this)->drawNormal(makeWrapper<Matrix_Int_>(matrix_));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ & matrix_, Function_ && function_) const noexcept {
-				return static_cast<const Derived*>(this)->drawNormal(makeWrapper(matrix_), function_);
+				return static_cast<const Derived*>(this)->drawNormal(makeWrapper<Matrix_Int_>(matrix_), function_);
 			}
 
 			//LayerSTL
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ & matrix_, const Index_Size layer_) const noexcept {
-				return static_cast<const Derived*>(this)->drawNormal(makeWrapper(matrix_, layer_));
+				return static_cast<const Derived*>(this)->drawNormal(makeWrapper<Matrix_Int_>(matrix_, layer_));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ & matrix_, const Index_Size layer_, Function_ && function_) const noexcept {
-				return static_cast<const Derived*>(this)->drawNormal(makeWrapper(matrix_, layer_), function_);
+				return static_cast<const Derived*>(this)->drawNormal(makeWrapper<Matrix_Int_>(matrix_, layer_), function_);
 			}
 
 			//Normal
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ & matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return static_cast<const Derived*>(this)->drawNormal(makeWrapper(matrix_, max_x_, max_y_));
+				return static_cast<const Derived*>(this)->drawNormal(makeWrapper<Matrix_Int_>(matrix_, max_x_, max_y_));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ & matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return static_cast<const Derived*>(this)->drawNormal(makeWrapper(matrix_, max_x_, max_y_), function_);
+				return static_cast<const Derived*>(this)->drawNormal(makeWrapper<Matrix_Int_>(matrix_, max_x_, max_y_), function_);
 			}
 
 			//LayerNormal
 			template<typename Matrix_>
 			constexpr bool draw(Matrix_ & matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return static_cast<const Derived*>(this)->drawNormal(makeWrapper(matrix_, layer_, max_x_, max_y_));
+				return static_cast<const Derived*>(this)->drawNormal(makeWrapper<Matrix_Int_>(matrix_, layer_, max_x_, max_y_));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperator(Matrix_ & matrix_, const Index_Size layer_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return static_cast<const Derived*>(this)->drawNormal(makeWrapper(matrix_, layer_, max_x_, max_y_), function_);
+				return static_cast<const Derived*>(this)->drawNormal(makeWrapper<Matrix_Int_>(matrix_, layer_, max_x_, max_y_), function_);
 			}
 
 			//Array
 			template<typename Matrix_>
 			constexpr bool drawArray(Matrix_ & matrix_, const Index_Size max_x_, const Index_Size max_y_) const noexcept {
-				return static_cast<const Derived*>(this)->drawNormal(makeWrapper(matrix_, max_x_, max_y_));
+				return static_cast<const Derived*>(this)->drawNormal(makeWrapper<Matrix_Int_>(matrix_, max_x_, max_y_));
 			}
 			template<typename Matrix_, typename Function_>
 			constexpr bool drawOperatorArray(Matrix_ & matrix_, const Index_Size max_x_, const Index_Size max_y_, Function_ && function_) const noexcept {
-				return static_cast<const Derived*>(this)->drawNormal(makeWrapper(matrix_, max_x_, max_y_), function_);
+				return static_cast<const Derived*>(this)->drawNormal(makeWrapper<Matrix_Int_>(matrix_, max_x_, max_y_), function_);
 			}
 
 

--- a/include/DTL/Utility/MatrixWrapper.hpp
+++ b/include/DTL/Utility/MatrixWrapper.hpp
@@ -13,9 +13,16 @@
 #include <cassert>
 #include <cstddef>
 #include <array>
+#include <bitset>
 #include <type_traits>
+#include <utility>
 #include <DTL/Macros/constexpr.hpp>
 #include <DTL/Type/Forward.hpp>
+#include <DTL/Type/SizeT.hpp>
+
+#ifdef DTL_USE_BOOST_ARRAY
+#include <boost/array.hpp>
+#endif
 
 /*#######################################################################################
 	[概要] "dtl名前空間"とは"DungeonTemplateLibrary"の全ての機能が含まれる名前空間である。
@@ -24,253 +31,230 @@
 namespace dtl {
 	inline namespace utility { //"dtl::utility"名前空間に属する
 
-		// ネストした ::std::array 用別名
-
-		template<typename Matrix_Int_, ::std::size_t max_x_, ::std::size_t max_y_>
-		using array2D = ::std::array< ::std::array<Matrix_Int_, max_x_>, max_y_>;
-
-		template<typename Matrix_Int_, ::std::size_t max_l_, ::std::size_t max_x_, ::std::size_t max_y_>
-		using array3D = ::std::array< ::std::array< ::std::array<Matrix_Int_, max_l_>, max_x_>, max_y_>;
-
-
 		// Detection Ideom 用ユーティリティ
-
-		template <class... Types>
-		struct voidHelper {
-			using type = void;
+		template<typename...>
+		struct void_helper {
+		  using type = void;
 		};
 
-		template <class... Types>
-		using void_t = typename voidHelper<Types...>::type;
+		template<typename... Ts>
+		using void_t = typename void_helper<Ts...>::type;
 
 
-		// ネストした ::std::array 判別用トレイツ
-
-		template<typename Matrix_>
-		struct is_Array2D : ::std::false_type {};
-
-		template<typename Matrix_Int_, ::std::size_t max_y_, ::std::size_t max_x_>
-		struct is_Array2D<array2D<Matrix_Int_, max_x_, max_y_>> : ::std::true_type {};
-
-		template<typename Matrix_>
-		struct is_Array3D : ::std::false_type {};
-
-		template<typename Matrix_Int_, ::std::size_t max_y_, ::std::size_t max_x_, ::std::size_t max_l_>
-		struct is_Array3D<array3D<Matrix_Int_, max_l_, max_x_, max_y_>> : ::std::true_type {};
+		// 型リスト保持用クラステンプレート
+		template<typename...>
+		struct TList {};
 
 
-		// ::std::array 以外の STL コンテナ判別用トレイツ
+		// 要素型取得用クラステンプレート
+		template<typename, typename = void>
+		struct to_element {
+			static constexpr bool value = false;
+		};
 
-		template<typename Matrix_, typename = void>
-		struct is_STL2D : ::std::false_type {};
+		template<typename T>
+		struct to_element<T, void_t<decltype(std::declval<T&>()[0])>> {
+			static constexpr bool value = true;
+			using type = typename std::remove_reference<decltype(std::declval<T&>()[0])>::type;
+		};
 
-		template<typename Matrix_>
-		struct is_STL2D<Matrix_, void_t<typename Matrix_::value_type::value_type>>
-		: ::std::conditional<is_Array2D<Matrix_>::value, ::std::false_type, ::std::is_integral<typename Matrix_::value_type::value_type>>::type {};
-
-		template<typename Matrix_, typename = void>
-		struct is_STL3D : ::std::false_type {};
-
-		template<typename Matrix_>
-		struct is_STL3D<Matrix_, void_t<typename Matrix_::value_type::value_type::value_type>>
-		: ::std::conditional<is_Array3D<Matrix_>::value, ::std::false_type, ::std::is_integral<typename Matrix_::value_type::value_type::value_type>>::type {};
+		template<typename T>
+		using to_element_t = typename to_element<T>::type;
 
 
-		// 要素アクセス用ベースクラス
+		// Matrix のカテゴリ
+		// サイズはコンストラクタ引数で決定(メンバ変数に保持)
+		template<typename T>
+		struct mcat_fixed {
+			using is_jagged = std::false_type;
 
-		template<typename Matrix_, typename Matrix_Int_, typename Index_Size_>
-		struct MatrixBase {
+			constexpr ::dtl::type::size get(const T&) const noexcept { return max_; }
+			constexpr mcat_fixed(::dtl::type::size max_) noexcept : max_(max_) {}
+
+		private:
+			::dtl::type::size max_;
+		};
+
+		// サイズはコンパイル時に決定
+		template<typename T, ::dtl::type::size N>
+		struct mcat_const {
+			using is_jagged = std::false_type;
+
+			constexpr ::dtl::type::size get(const T &) const noexcept { return N; }
+		};
+
+		// サイズはMatrixのメンバ関数で取得
+		template<typename T>
+		struct mcat_memfn {
+			using is_jagged = std::true_type;
+
+			constexpr ::dtl::type::size get(const T& v) const noexcept(noexcept(v.size())) { return v.size(); }
+		};
+
+
+		// 共通基底クラステンプレート
+		template<typename B, typename V, typename M, typename TY, typename TX>
+		struct MatrixWrapperCommon : TX, TY {
+			using Index_Size = ::dtl::type::size;
+			using is_jagged = typename TX::is_jagged;
+
+			constexpr MatrixWrapperCommon(M& mat, Index_Size max_x, Index_Size max_y) noexcept : TX(max_x), TY(max_y), mat(mat) {}
+			constexpr MatrixWrapperCommon(M& mat) noexcept : mat(mat) {}
+
+			constexpr Index_Size getX(const Index_Size pos = 0) const
+				noexcept(noexcept(std::declval<MatrixWrapperCommon>().getY()) && noexcept(std::declval<TX>().get(std::declval<M&>()[0]))) {
+				return is_jagged::value && getY() <= pos ? 0 : TX::get(mat[pos]);
+			}
+			constexpr Index_Size getY() const noexcept(noexcept(std::declval<TY>().get(std::declval<M&>()))) {
+				return TY::get(mat);
+			}
+
 			DTL_VERSIONING_CPP14_CONSTEXPR
-			void set(const Index_Size_ point_x_, const Index_Size_ point_y_, const Matrix_Int_ value_) noexcept {
-				static_cast<Matrix_&>(*this)(point_x_, point_y_) = value_;
+			void set(const Index_Size point_x_, const Index_Size point_y_, V value_)
+			noexcept(noexcept(std::declval<B&>()(0, 0) = 0)) {
+				static_cast<B&>(*this)(point_x_, point_y_) = value_;
 			}
 			template<typename Function_>
 			DTL_VERSIONING_CPP14_CONSTEXPR
-			void set(const Index_Size_ point_x_, const Index_Size_ point_y_, const Matrix_Int_ value_, Function_&& function_) noexcept {
-				if (function_(static_cast<Matrix_&>(*this)(point_x_, point_y_)))
-					static_cast<Matrix_&>(*this)(point_x_, point_y_) = value_;
+			void set(const Index_Size point_x_, const Index_Size point_y_, V value_, Function_&& function_)
+				noexcept(noexcept(function_(std::declval<B&>()(0, 0))) && noexcept(std::declval<B&>()(0, 0) = 0)) {
+				if (function_(static_cast<B&>(*this)(point_x_, point_y_)))
+					static_cast<B&>(*this)(point_x_, point_y_) = value_;
 			}
+
+		protected:
+			M& mat;
 		};
 
 
-		// Matrix 用ラッパークラス
+		// MatrixWrapperの1次元用基底クラステンプレート
+		template<typename V, typename M, typename = void_t<decltype(std::declval<M&>()[0] = std::declval<V>())>>
+		struct MatrixWrapperBase1 : MatrixWrapperCommon<MatrixWrapperBase1<V, M>, V, M, mcat_fixed<M>, mcat_fixed<to_element_t<M>>> {
+			using Base_t = MatrixWrapperCommon<MatrixWrapperBase1, V, M, mcat_fixed<M>, mcat_fixed<to_element_t<M>>>;
+			using Index_Size = typename Base_t::Index_Size;
 
-		template<typename Matrix_, typename = void>
-		struct MatrixWrapper;
-
-		// 2次元配列
-		template<typename Matrix_Int_, ::std::size_t max_y_, ::std::size_t max_x_>
-		struct MatrixWrapper<Matrix_Int_[max_y_][max_x_]>
-			: MatrixBase<MatrixWrapper<Matrix_Int_[max_y_][max_x_]>, Matrix_Int_, ::std::size_t> {
-			using Matrix = Matrix_Int_[max_y_][max_x_];
-			using Matrix_Int = Matrix_Int_;
-			using Index_Size = ::std::size_t;
-			using is_jagged = ::std::false_type;
-			constexpr MatrixWrapper(Matrix& mat) noexcept : mat(mat) {}
-			DTL_VERSIONING_CPP14_CONSTEXPR
-			MatrixWrapper(Matrix& mat, const Index_Size max_x, const Index_Size max_y) : mat(mat) { assert(max_x_ == max_x); assert(max_y_ == max_y); }
-			constexpr Index_Size getX() const noexcept { return max_x_; }
-			constexpr Index_Size getY() const noexcept { return max_y_; }
-			Matrix& mat;
-			Matrix_Int& operator()(Index_Size x, Index_Size y) noexcept { return mat[y][x]; }
+			using Base_t::Base_t;
+			decltype(std::declval<M&>()[0]) operator()(Index_Size x, Index_Size y) noexcept(noexcept(std::declval<M&>()[0])) { return Base_t::mat[y * Base_t::getX() + x]; }
 		};
 
-		// 2次元配列(サイズ不明)
-		template<typename Matrix_Int_, ::std::size_t max_x_>
-		struct MatrixWrapper<Matrix_Int_(*)[max_x_]>
-			: MatrixBase<MatrixWrapper<Matrix_Int_(*)[max_x_]>, Matrix_Int_, ::std::size_t> {
-			using Matrix = Matrix_Int_(*)[max_x_];
-			using Matrix_Int = Matrix_Int_;
-			using Index_Size = ::std::size_t;
-			using is_jagged = ::std::false_type;
-			Matrix mat;
-			Index_Size max_y_;
-			DTL_VERSIONING_CPP14_CONSTEXPR
-			MatrixWrapper(Matrix mat, const Index_Size max_x, const Index_Size max_y) : mat(mat), max_y_(max_y) { assert(max_x_ == max_x); }
-			constexpr Index_Size getX() const noexcept { return max_x_; }
-			constexpr Index_Size getY() const noexcept { return max_y_; }
-			Matrix_Int& operator()(Index_Size x, Index_Size y) noexcept { return mat[y][x]; }
+		// MatrixWrapperの2次元用基底クラステンプレート
+		template<typename V, typename M, typename TY, typename TX, typename = void_t<decltype(std::declval<M&>()[0][0] = std::declval<V>())>>
+		struct MatrixWrapperBase2 : MatrixWrapperCommon<MatrixWrapperBase2<V, M, TY, TX>, V, M, TY, TX> {
+			using Base_t = MatrixWrapperCommon<MatrixWrapperBase2, V, M, TY, TX>;
+			using Index_Size = typename Base_t::Index_Size;
+
+			using Base_t::Base_t;
+			decltype(std::declval<M&>()[0][0]) operator()(Index_Size x, Index_Size y) noexcept(noexcept(std::declval<M&>()[0][0])) { return Base_t::mat[y][x]; }
 		};
 
-		// 3次元配列
-		template<typename Matrix_Int_, ::std::size_t max_y_, ::std::size_t max_x_, ::std::size_t max_l_>
-		struct MatrixWrapper<Matrix_Int_[max_y_][max_x_][max_l_]>
-			: MatrixBase<MatrixWrapper<Matrix_Int_[max_y_][max_x_][max_l_]>, Matrix_Int_, ::std::size_t> {
-			using Matrix = Matrix_Int_[max_y_][max_x_][max_l_];
-			using Matrix_Int = Matrix_Int_;
-			using Index_Size = ::std::size_t;
-			using is_jagged = ::std::false_type;
-			Matrix& mat;
-			Index_Size layer_;
-			constexpr MatrixWrapper(Matrix& mat, const Index_Size layer) noexcept : mat(mat), layer_(layer) {}
-			DTL_VERSIONING_CPP14_CONSTEXPR
-			MatrixWrapper(Matrix& mat, const Index_Size layer, const Index_Size max_x, const Index_Size max_y) : mat(mat), layer_(layer) { assert(max_x_ == max_x); assert(max_y_ == max_y); }
-			constexpr Index_Size getX() const noexcept { return max_x_; }
-			constexpr Index_Size getY() const noexcept { return max_y_; }
-			Matrix_Int& operator()(Index_Size x, Index_Size y) noexcept { return mat[y][x][layer_]; }
+		// MatrixWrapperの3次元用基底クラステンプレート
+		template<typename V, typename M, typename TY, typename TX, typename = void_t<decltype(std::declval<M&>()[0][0][0] = std::declval<V>())>>
+		struct MatrixWrapperBase3 : MatrixWrapperCommon<MatrixWrapperBase3<V, M, TY, TX>, V, M, TY, TX> {
+			using Base_t = MatrixWrapperCommon<MatrixWrapperBase3, V, M, TY, TX>;
+			using Index_Size = typename Base_t::Index_Size;
+
+			constexpr MatrixWrapperBase3(M& mat, Index_Size draw_layer, Index_Size max_x, Index_Size max_y) noexcept: Base_t(mat, max_x, max_y), draw_layer_(draw_layer)  {}
+			constexpr MatrixWrapperBase3(M& mat, Index_Size draw_layer) noexcept : Base_t(mat), draw_layer_(draw_layer) {}
+			decltype(std::declval<M&>()[0][0][0]) operator()(Index_Size x, Index_Size y) noexcept(noexcept(std::declval<M&>()[0][0][0])) { return Base_t::mat[y][x][draw_layer_]; }
+
+		private:
+			Index_Size draw_layer_;
 		};
 
-		// 3次元配列(サイズ不明)
-		template<typename Matrix_Int_, ::std::size_t max_x_, ::std::size_t max_l_>
-		struct MatrixWrapper<Matrix_Int_(*)[max_x_][max_l_]>
-			: MatrixBase<MatrixWrapper<Matrix_Int_(*)[max_x_][max_l_]>, Matrix_Int_, ::std::size_t> {
-			using Matrix = Matrix_Int_(*)[max_x_][max_l_];
-			using Matrix_Int = Matrix_Int_;
-			using Index_Size = ::std::size_t;
-			using is_jagged = ::std::false_type;
-			Matrix mat;
-			Index_Size layer_;
-			Index_Size max_y_;
-			DTL_VERSIONING_CPP14_CONSTEXPR
-			MatrixWrapper(Matrix mat, const Index_Size layer, const Index_Size max_x, const Index_Size max_y) : mat(mat), layer_(layer), max_y_(max_y) { assert(max_x_ == max_x); }
-			constexpr Index_Size getX() const noexcept { return max_x_; }
-			constexpr Index_Size getY() const noexcept { return max_y_; }
-			Matrix_Int& operator()(Index_Size x, Index_Size y) noexcept { return mat[y][x][layer_]; }
+
+		// Matrix解析用クラステンプレート
+		// プライマリテンプレート
+		template<typename, typename = TList<>, typename = void>
+		struct MatrixWrapperImpl;
+
+		// ポインタ
+		template<typename E, typename... Ts>
+		struct MatrixWrapperImpl<E*, TList<Ts...>, void_t<to_element_t<E*>>> : MatrixWrapperImpl<E, TList<Ts..., mcat_fixed<E*>>> {};
+
+		// 配列
+		template<typename E, ::dtl::type::size N, typename... Ts>
+		struct MatrixWrapperImpl<E[N], TList<Ts...>, void_t<to_element_t<E[N]>>> : MatrixWrapperImpl<E, TList<Ts..., mcat_const<E[N], N>>> {};
+
+		// std::array
+		template<typename E, ::dtl::type::size N, typename... Ts>
+		struct MatrixWrapperImpl<std::array<E, N>, TList<Ts...>, void_t<to_element_t<std::array<E, N>>>> : MatrixWrapperImpl<E, TList<Ts..., mcat_const<std::array<E, N>, N>>> {};
+
+#ifdef DTL_USE_BOOST_ARRAY
+		// boost::array
+		template<typename E, ::dtl::type::size N, typename... Ts>
+		struct MatrixWrapperImpl<boost::array<E, N>, TList<Ts...>, void_t<to_element_t<boost::array<E, N>>>> : MatrixWrapperImpl<E, TList<Ts..., mcat_const<boost::array<E, N>, N>>> {};
+#endif
+
+		// std::bitset
+		template<::dtl::type::size N, typename... Ts>
+		struct MatrixWrapperImpl<std::bitset<N>, TList<Ts...>, void_t<to_element_t<std::bitset<N>>>> : MatrixWrapperImpl<bool, TList<Ts..., mcat_const<std::bitset<N>, N>>> {};
+
+		// 上記以外
+		template<typename T, typename... Ts>
+		struct MatrixWrapperImpl<T, TList<Ts...>, void_t<to_element_t<T>>> : MatrixWrapperImpl<to_element_t<T>, TList<Ts..., mcat_memfn<T>>> {};
+
+		// 1次元
+		template<typename T, typename TX>
+		struct MatrixWrapperImpl<T, TList<TX>, typename std::enable_if<!to_element<T>::value>::type> {
+			template<typename V, typename M>
+			using Base_t = MatrixWrapperBase1<V, M>;
 		};
 
-		// 2次元 ::std::array
-		template<typename Matrix_Int_, ::std::size_t max_y_, ::std::size_t max_x_>
-		struct MatrixWrapper<array2D<Matrix_Int_, max_x_, max_y_>>
-			: MatrixBase<MatrixWrapper<array2D<Matrix_Int_, max_x_, max_y_>>, Matrix_Int_, ::std::size_t> {
-			using Matrix = array2D<Matrix_Int_, max_x_, max_y_>;
-			using Matrix_Int = Matrix_Int_;
-			using Index_Size = ::std::size_t;
-			using is_jagged = ::std::false_type;
-			Matrix& mat;
-			constexpr MatrixWrapper(Matrix& mat) noexcept : mat(mat) {}
-			DTL_VERSIONING_CPP14_CONSTEXPR
-			MatrixWrapper(Matrix& mat, const Index_Size max_x, const Index_Size max_y) : mat(mat) { assert(max_x_ == max_x); assert(max_y_ == max_y); }
-			constexpr Index_Size getX() const noexcept { return max_x_; }
-			constexpr Index_Size getY() const noexcept { return max_y_; }
-			Matrix_Int& operator()(Index_Size x, Index_Size y) noexcept { return mat[y][x]; }
+		// 2次元
+		template<typename T, typename TY, typename TX>
+		struct MatrixWrapperImpl<T, TList<TY, TX>, typename std::enable_if<!to_element<T>::value>::type> {
+			template<typename V, typename M>
+			using Base_t = MatrixWrapperBase2<V, M, TY, TX>;
 		};
 
-		// 3次元 ::std::array
-		template<typename Matrix_Int_, ::std::size_t max_y_, ::std::size_t max_x_, ::std::size_t max_l_>
-		struct MatrixWrapper<array3D<Matrix_Int_, max_l_, max_x_, max_y_>>
-			: MatrixBase<MatrixWrapper<array3D<Matrix_Int_, max_l_, max_x_, max_y_>>, Matrix_Int_, ::std::size_t> {
-			using Matrix = array3D<Matrix_Int_, max_l_, max_x_, max_y_>;
-			using Matrix_Int = Matrix_Int_;
-			using Index_Size = ::std::size_t;
-			using is_jagged = ::std::false_type;
-			Matrix& mat;
-			Index_Size layer_;
-			constexpr MatrixWrapper(Matrix& mat, const Index_Size layer) noexcept : mat(mat), layer_(layer) {}
-			constexpr Index_Size getX() const noexcept { return max_x_; }
-			constexpr Index_Size getY() const noexcept { return max_y_; }
-			Matrix_Int& operator()(Index_Size x, Index_Size y) noexcept { return mat[y][x][layer_]; }
+		// 3次元
+		template<typename T, typename TY, typename TX, typename TL>
+		struct MatrixWrapperImpl<T, TList<TY, TX, TL>, typename std::enable_if<!to_element<T>::value>::type> {
+			template<typename V, typename M>
+			using Base_t = MatrixWrapperBase3<V, M, TY, TX>;
 		};
 
-		// 1次元配列
-		template<typename Matrix_Int_, ::std::size_t max_len_>
-		struct MatrixWrapper<Matrix_Int_[max_len_]>
-			: MatrixBase<MatrixWrapper<Matrix_Int_[max_len_]>, Matrix_Int_, ::std::size_t> {
-			using Matrix = Matrix_Int_[max_len_];
-			using Matrix_Int = Matrix_Int_;
-			using Index_Size = ::std::size_t;
-			using is_jagged = ::std::false_type;
-			Matrix& mat;
-			Index_Size max_x_;
-			DTL_VERSIONING_CPP14_CONSTEXPR
-			MatrixWrapper(Matrix& mat, const Index_Size max_x, const Index_Size max_y) : mat(mat), max_x_(max_x) { assert(max_x * max_y == max_len_); }
-			constexpr Index_Size getX() const noexcept { return max_x_; }
-			constexpr Index_Size getY() const noexcept { return max_len_ / max_x_; }
-			Matrix_Int& operator()(Index_Size x, Index_Size y) noexcept { return mat[y * max_x_ + x]; }
+
+		// MatrixWrapperのプライマリテンプレート。2 or 3次元用。MatrixWrapperImpl::Base_tに委譲
+		template<typename V, typename M, ::dtl::type::size N, typename = void>
+		struct MatrixWrapper : MatrixWrapperImpl<M>::template Base_t<V, M> {
+			using Base_t = typename MatrixWrapperImpl<M>::template Base_t<V, M>;
+
+			using Base_t::Base_t;
 		};
 
-		// 1次元配列(サイズ不明)
-		template<typename Matrix_Int_>
-		struct MatrixWrapper<Matrix_Int_*>
-			: MatrixBase<MatrixWrapper<Matrix_Int_*>, Matrix_Int_, ::std::size_t> {
-			using Matrix = Matrix_Int_*;
-			using Matrix_Int = Matrix_Int_;
-			using Index_Size = ::std::size_t;
-			using is_jagged = ::std::false_type;
-			Matrix mat;
-			Index_Size max_x_;
-			Index_Size max_y_;
-			constexpr MatrixWrapper(Matrix mat, const Index_Size max_x, const Index_Size max_y) noexcept : mat(mat), max_x_(max_x), max_y_(max_y) {}
-			constexpr Index_Size getX() const noexcept { return max_x_; }
-			constexpr Index_Size getY() const noexcept { return max_y_; }
-			Matrix_Int& operator()(Index_Size x, Index_Size y) noexcept { return mat[y * max_x_ + x]; }
+		// 引数2個、1次元用。MatrixWrapperBase1に委譲
+		template<typename V, typename M>
+		struct MatrixWrapper<V, M, 2, typename std::enable_if<!to_element<to_element_t<M>>::value>::type>
+		: MatrixWrapperBase1<V, M> {
+			using Base_t = MatrixWrapperBase1<V, M>;
+
+			using Base_t::Base_t;
 		};
 
-		// 2次元 STL コンテナ
-		template<typename Matrix_>
-		struct MatrixWrapper<Matrix_, typename ::std::enable_if<is_STL2D<Matrix_>::value>::type>
-			: MatrixBase<MatrixWrapper<Matrix_, typename ::std::enable_if<is_STL2D<Matrix_>::value>::type>, typename Matrix_::value_type::value_type, typename Matrix_::size_type> {
-			using Matrix = Matrix_;
-			using Matrix_Int = typename Matrix_::value_type::value_type;
-			using Index_Size = typename Matrix_::size_type;
-			using is_jagged = ::std::true_type;
-			Matrix& mat;
-			constexpr MatrixWrapper(Matrix& mat) noexcept : mat(mat) {}
-			constexpr Index_Size getX() const noexcept { return mat.size() == 0 ? 0 : mat[0].size(); }
-			constexpr Index_Size getX(const Index_Size row) const noexcept { return row >= mat.size() ? 0 : mat[row].size(); }
-			constexpr Index_Size getY() const noexcept { return mat.size(); }
-			Matrix_Int& operator()(Index_Size x, Index_Size y) noexcept { return mat[y][x]; }
+		// 引数2個、2次元用。MatrixWrapperBase2に委譲
+		template<typename V, typename M>
+		struct MatrixWrapper<V, M, 2, typename std::enable_if<to_element<to_element_t<M>>::value>::type>
+		: MatrixWrapperBase2<V, M, mcat_fixed<M>, mcat_fixed<to_element_t<M>>> {
+			using Base_t = MatrixWrapperBase2<V, M, mcat_fixed<M>, mcat_fixed<to_element_t<M>>>;
+
+			using Base_t::Base_t;
 		};
 
-		// 3次元 STL コンテナ
-		template<typename Matrix_>
-			struct MatrixWrapper<Matrix_, typename ::std::enable_if<is_STL3D<Matrix_>::value>::type>
-			: MatrixBase<MatrixWrapper<Matrix_, typename ::std::enable_if<is_STL3D<Matrix_>::value>::type>, typename Matrix_::value_type::value_type, typename Matrix_::size_type> {
-			using Matrix = Matrix_;
-			using Matrix_Int = typename Matrix_::value_type::value_type::value_type;
-			using Index_Size = typename Matrix::size_type;
-			using is_jagged = ::std::true_type;
-			Matrix& mat;
-			Index_Size layer_;
-			constexpr MatrixWrapper(Matrix& mat, const Index_Size layer) noexcept : mat(mat), layer_(layer) {}
-			constexpr Index_Size getX() const noexcept { return mat.size() == 0 ? 0 : mat[0].size(); }
-			constexpr Index_Size getX(const Index_Size row) const noexcept { return row >= mat.size() ? 0 : mat[row].size(); }
-			constexpr Index_Size getY() const noexcept { return mat.size(); }
-			Matrix_Int& operator()(Index_Size x, Index_Size y) noexcept { return mat[y][x][layer_]; }
+		// 引数3個、3次元用。MatrixWrapperBase3に委譲
+		template<typename V, typename M>
+		struct MatrixWrapper<V, M, 3>
+		: MatrixWrapperBase3<V, M, mcat_fixed<M>, mcat_fixed<to_element_t<M>>> {
+			using Base_t = MatrixWrapperBase3<V, M, mcat_fixed<M>, mcat_fixed<to_element_t<M>>>;
+
+			using Base_t::Base_t;
 		};
 
-		template<typename Matrix_, typename... Args_>
-		constexpr MatrixWrapper<typename ::std::remove_reference<Matrix_>::type> makeWrapper(Matrix_&& mat, Args_&&... args_) {
-			return MatrixWrapper<typename ::std::remove_reference<Matrix_>::type>(mat, DTL_TYPE_FORWARD<Args_>(args_)...);
+
+		// MatrixWrapper生成用ユーティリティ関数
+		template<typename V, typename M, typename... Args>
+		constexpr MatrixWrapper<V, typename std::remove_reference<M>::type, sizeof...(Args)> makeWrapper(M&& mat, Args&&... args) {
+			return MatrixWrapper<V, typename std::remove_reference<M>::type, sizeof...(Args)>(mat, DTL_TYPE_FORWARD<Args>(args)...);
 		}
 	}
 }


### PR DESCRIPTION
前回の Pull Request でいろいろと問題があったため、各種修正を行った上で、
Matrix の任意の次元に以下のコンテナを使用できる事を確認しました。

生配列
std::array
std::deque
std::vector(bool除く)
boost::array
boost::container::deque
boost::container::small_vector
boost::container::stable_vector
boost::container::static_vector
boost::container::vector(bool除く)

また、Matrix の最終次元には以下のコンテナも使用できる事を確認しました。

std::bitset
std::string
std::vector<bool>
boost::container::string
boost::container::vector<bool>
boost::dynamic_bitset

更に、単独であれば boost::multi_array も使用可能な事を確認しました。

これらを使用した場合、draw() メンバ関数等にサイズのパラメータを与えなけ
れば、基本的に size() メンバ関数を使用してサイズを決定しようとしますが、
生配列、std::array、および、std::bitset の場合はテンプレートパラメータか
ら自動的に決定します。

なお、boost::array の場合もテンプレートパラメータから自動的に決定できま
すが、その場合は boost/array.hpp ヘッダをインクルードしなければならない
ため、DTL_USE_BOOST_ARRAY マクロを定義している場合に限ってテンプレートパ
ラメータからサイズを決定するようになっています。
（そうでない場合は size() メンバ関数を呼び出す形になります）

基底クラスに DrawJagged を使用した場合、いずれの場合でも先頭の引数が
MatrixWrapper になった drawNormal が呼ばれるようになっていますが、この際
に X 軸（幅）方向に size() メンバ関数を使用するかどうかを判別できるよう
に MatrixWrapper::is_jagged::value なる bool 型のネストしたメンバ変数を
持っているので（true の場合は size() を呼び出す）、このメンバ変数を使用
すれば Matrix の形が完全な四角形の場合とそれ以外の場合とで挙動を変更する
ことができます。（Border 等を参照してください）

但し、draw メンバ関数等で幅の指定をした場合にはそちらが優先され、Matrix
は完全な四角形とみなされます。
（MatrixWrapper::is_jagged::value が false になる）

また、boost::multi_array は本来は完全な四角形ですが、size() メンバ関数で
幅の決定をする関係上、MatrixWrapper::is_jagged::value は true になってし
まっています。（許してください…）

ちなみに、1次元の場合でも drawArray ではなく draw を使用することと、生配
列以外のコンテナを使用することが可能ですが、サイズは必ず引数として指定す
る必要があります。