### PR TITLE
CRTP のテンプレート引数の記載を修正しました。

### DIFF
--- a/include/DTL/Shape/Border.hpp
+++ b/include/DTL/Shape/Border.hpp
@@ -43,8 +43,8 @@ namespace dtl {
 			///// エイリアス (Alias) /////
 
 			using Index_Size = ::dtl::type::size;
-			using ShapeBase_t = ::dtl::range::RectBaseWithValue<Border<Matrix_Int_>, Matrix_Int_>;
-			using DrawBase_t = ::dtl::utility::DrawJagged<Border<Matrix_Int_>, Matrix_Int_>;
+			using ShapeBase_t = ::dtl::range::RectBaseWithValue<Border, Matrix_Int_>;
+			using DrawBase_t = ::dtl::utility::DrawJagged<Border, Matrix_Int_>;
 
 			friend DrawBase_t;
 

--- a/include/DTL/Shape/BorderOdd.hpp
+++ b/include/DTL/Shape/BorderOdd.hpp
@@ -44,8 +44,8 @@ namespace dtl {
 			///// エイリアス (Alias) /////
 
 			using Index_Size = ::dtl::type::size;
-			using ShapeBase_t = ::dtl::range::RectBaseWithValue<BorderOdd<Matrix_Int_>, Matrix_Int_>;
-			using DrawBase_t = ::dtl::utility::DrawJagged<BorderOdd<Matrix_Int_>, Matrix_Int_>;
+			using ShapeBase_t = ::dtl::range::RectBaseWithValue<BorderOdd, Matrix_Int_>;
+			using DrawBase_t = ::dtl::utility::DrawJagged<BorderOdd, Matrix_Int_>;
 
 			friend DrawBase_t;
 

--- a/include/DTL/Shape/DiamondSquareAverageCornerIsland.hpp
+++ b/include/DTL/Shape/DiamondSquareAverageCornerIsland.hpp
@@ -37,14 +37,14 @@ namespace dtl {
 			"Matrixの描画範囲にダイヤモンドスクエア法に従って描画値を設置する" 機能を持つクラスである。
 #######################################################################################*/
 		template<typename Matrix_Int_>
-		class DiamondSquareAverageCornerIsland : public ::dtl::range::RectBaseFractal< ::dtl::shape::DiamondSquareAverageCornerIsland<Matrix_Int_>, Matrix_Int_> {
+		class DiamondSquareAverageCornerIsland : public ::dtl::range::RectBaseFractal<DiamondSquareAverageCornerIsland<Matrix_Int_>, Matrix_Int_> {
 		private:
 
 
 			///// エイリアス (Alias) /////
 
 			using Index_Size = ::dtl::type::size;
-			using ShapeBase_t = ::dtl::range::RectBaseFractal< ::dtl::shape::DiamondSquareAverageCornerIsland<Matrix_Int_>, Matrix_Int_>;
+			using ShapeBase_t = ::dtl::range::RectBaseFractal<DiamondSquareAverageCornerIsland, Matrix_Int_>;
 
 
 			///// サイズ取得 /////

--- a/include/DTL/Shape/DiamondSquareAverageIsland.hpp
+++ b/include/DTL/Shape/DiamondSquareAverageIsland.hpp
@@ -37,14 +37,14 @@ namespace dtl {
 			"Matrixの描画範囲にダイヤモンドスクエア法に従って描画値を設置する" 機能を持つクラスである。
 #######################################################################################*/
 		template<typename Matrix_Int_>
-		class DiamondSquareAverageIsland : public ::dtl::range::RectBaseFractal< ::dtl::shape::DiamondSquareAverageIsland<Matrix_Int_>, Matrix_Int_> {
+		class DiamondSquareAverageIsland : public ::dtl::range::RectBaseFractal<DiamondSquareAverageIsland<Matrix_Int_>, Matrix_Int_> {
 		private:
 
 
 			///// エイリアス (Alias) /////
 
 			using Index_Size = ::dtl::type::size;
-			using ShapeBase_t = ::dtl::range::RectBaseFractal< ::dtl::shape::DiamondSquareAverageIsland<Matrix_Int_>, Matrix_Int_>;
+			using ShapeBase_t = ::dtl::range::RectBaseFractal<DiamondSquareAverageIsland, Matrix_Int_>;
 
 
 			///// サイズ取得 /////

--- a/include/DTL/Shape/FractalIsland.hpp
+++ b/include/DTL/Shape/FractalIsland.hpp
@@ -39,14 +39,14 @@ namespace dtl {
 
 		//マスを指定した数値で埋める
 		template<typename Matrix_Int_, typename UniquePtr_ = DTL_TYPE_UNIQUE_PTR<::dtl::type::ssize[]>>
-		class FractalIsland : public ::dtl::range::RectBaseFractal< ::dtl::shape::FractalIsland<Matrix_Int_>, Matrix_Int_> {
+		class FractalIsland : public ::dtl::range::RectBaseFractal<FractalIsland<Matrix_Int_, UniquePtr_>, Matrix_Int_> {
 		private:
 
 
 			///// エイリアス (Alias) /////
 
 			using Index_Size = ::dtl::type::size;
-			using ShapeBase_t = ::dtl::range::RectBaseFractal< ::dtl::shape::FractalIsland<Matrix_Int_>, Matrix_Int_>;
+			using ShapeBase_t = ::dtl::range::RectBaseFractal<FractalIsland, Matrix_Int_>;
 
 
 			///// 基本処理 /////

--- a/include/DTL/Shape/FractalLoopIsland.hpp
+++ b/include/DTL/Shape/FractalLoopIsland.hpp
@@ -39,14 +39,14 @@ namespace dtl {
 
 		//マスを指定した数値で埋める
 		template<typename Matrix_Int_, typename UniquePtr_ = DTL_TYPE_UNIQUE_PTR<::dtl::type::ssize[]>>
-		class FractalLoopIsland : public ::dtl::range::RectBaseFractal< ::dtl::shape::FractalLoopIsland<Matrix_Int_>, Matrix_Int_> {
+		class FractalLoopIsland : public ::dtl::range::RectBaseFractal<FractalLoopIsland<Matrix_Int_, UniquePtr_>, Matrix_Int_> {
 		private:
 
 
 			///// エイリアス (Alias) /////
 
 			using Index_Size = ::dtl::type::size;
-			using ShapeBase_t = ::dtl::range::RectBaseFractal< ::dtl::shape::FractalLoopIsland<Matrix_Int_>, Matrix_Int_>;
+			using ShapeBase_t = ::dtl::range::RectBaseFractal<FractalLoopIsland, Matrix_Int_>;
 
 
 			///// 基本処理 /////

--- a/include/DTL/Shape/PerlinIsland.hpp
+++ b/include/DTL/Shape/PerlinIsland.hpp
@@ -45,8 +45,8 @@ namespace dtl {
 			///// エイリアス (Alias) /////
 
 			using Index_Size = ::dtl::type::size;
-			using ShapeBase_t = ::dtl::range::RectBasePerlin<PerlinIsland<Matrix_Int_>, Matrix_Int_>;
-			using DrawBase_t = ::dtl::utility::DrawJagged<PerlinIsland<Matrix_Int_>, Matrix_Int_>;
+			using ShapeBase_t = ::dtl::range::RectBasePerlin<PerlinIsland, Matrix_Int_>;
+			using DrawBase_t = ::dtl::utility::DrawJagged<PerlinIsland, Matrix_Int_>;
 
 			friend DrawBase_t;
 

--- a/include/DTL/Shape/PointGrid.hpp
+++ b/include/DTL/Shape/PointGrid.hpp
@@ -43,8 +43,8 @@ namespace dtl {
 			///// エイリアス (Alias) /////
 
 			using Index_Size = ::dtl::type::size;
-			using ShapeBase_t = ::dtl::range::RectBaseWithValue<PointGrid<Matrix_Int_>, Matrix_Int_>;
-			using DrawBase_t = ::dtl::utility::DrawJagged<PointGrid<Matrix_Int_>, Matrix_Int_>;
+			using ShapeBase_t = ::dtl::range::RectBaseWithValue<PointGrid, Matrix_Int_>;
+			using DrawBase_t = ::dtl::utility::DrawJagged<PointGrid, Matrix_Int_>;
 
 			friend DrawBase_t;
 

--- a/include/DTL/Shape/Rect.hpp
+++ b/include/DTL/Shape/Rect.hpp
@@ -43,8 +43,8 @@ namespace dtl {
 			///// エイリアス (Alias) /////
 
 			using Index_Size = ::dtl::type::size;
-			using ShapeBase_t = ::dtl::range::RectBaseWithValue<Rect<Matrix_Int_>, Matrix_Int_>;
-			using DrawBase_t = ::dtl::utility::DrawJagged<Rect<Matrix_Int_>, Matrix_Int_>;
+			using ShapeBase_t = ::dtl::range::RectBaseWithValue<Rect, Matrix_Int_>;
+			using DrawBase_t = ::dtl::utility::DrawJagged<Rect, Matrix_Int_>;
 
 			friend DrawBase_t;
 

--- a/include/DTL/Shape/Shogi.hpp
+++ b/include/DTL/Shape/Shogi.hpp
@@ -43,8 +43,8 @@ namespace dtl {
 			///// エイリアス (Alias) /////
 
 			using Index_Size = ::dtl::type::size;
-			using ShapeBase_t = ::dtl::range::RectBaseShogi<Shogi<Matrix_Int_>, Matrix_Int_>;
-			using DrawBase_t = ::dtl::utility::DrawJagged<Shogi<Matrix_Int_>, Matrix_Int_>;
+			using ShapeBase_t = ::dtl::range::RectBaseShogi<Shogi, Matrix_Int_>;
+			using DrawBase_t = ::dtl::utility::DrawJagged<Shogi, Matrix_Int_>;
 
 			friend DrawBase_t;
 

--- a/include/DTL/Shape/WhiteNoise.hpp
+++ b/include/DTL/Shape/WhiteNoise.hpp
@@ -32,14 +32,14 @@ namespace dtl {
 
 		//マスを指定した数値で埋める
 		template<typename Matrix_Int_>
-		class WhiteNoise : public ::dtl::range::RectBaseWithValue< ::dtl::shape::WhiteNoise<Matrix_Int_>, Matrix_Int_> {
+		class WhiteNoise : public ::dtl::range::RectBaseWithValue<WhiteNoise<Matrix_Int_>, Matrix_Int_> {
 		private:
 
 
 			///// エイリアス (Alias) /////
 
 			using Index_Size = ::dtl::type::size;
-			using ShapeBase_t = ::dtl::range::RectBaseWithValue< ::dtl::shape::WhiteNoise<Matrix_Int_>, Matrix_Int_>;
+			using ShapeBase_t = ::dtl::range::RectBaseWithValue<WhiteNoise, Matrix_Int_>;
 
 
 			///// 代入処理 /////


### PR DESCRIPTION
CRTP のテンプレート引数では名前空間修飾子は冗長なため、削除しました。

また、一部のクラステンプレートで、基底クラスのテンプレート引数が不足して
いたため追記しました。

更に、クラステンプレート定義内では Injection Name が使用できるため、
テンプレート引数を書かないようにしました。