### PR TITLE
BasicRect のコンストラクタを public に変更しました。

### DIFF
--- a/include/DTL/Range/BasicRect.hpp
+++ b/include/DTL/Range/BasicRect.hpp
@@ -57,6 +57,8 @@ namespace dtl {
 					: this->start_y + this->height;
 			}
 
+		public:
+
 			///// コンストラクタ (Constructor) /////
 
 			constexpr BasicRect() = default;
@@ -66,8 +68,6 @@ namespace dtl {
 			constexpr explicit BasicRect(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_) noexcept
 				:start_x(start_x_), start_y(start_y_),
 				width(width_), height(height_) {}
-
-		public:
 
 
 			///// メンバ変数の値を取得 (Get Value) /////

--- a/include/DTL/Range/RectBase.hpp
+++ b/include/DTL/Range/RectBase.hpp
@@ -55,11 +55,7 @@ namespace dtl {
 
 			///// コンストラクタ (Constructor) /////
 
-			constexpr RectBase() = default;
-			constexpr explicit RectBase(const ::dtl::base::MatrixRange& matrix_range_) noexcept
-				:RectBase_t(matrix_range_) {}
-			constexpr explicit RectBase(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_) noexcept
-				:RectBase_t(start_x_, start_y_, width_, height_) {}
+			using RectBase_t::RectBase_t;
 		};
 	}
 }

--- a/include/DTL/Range/RectBaseDobutsuShogi.hpp
+++ b/include/DTL/Range/RectBaseDobutsuShogi.hpp
@@ -36,6 +36,8 @@ namespace dtl {
 			Matrix_Int_ lion_1{};
 			Matrix_Int_ lion_2{};
 
+			constexpr DobutsuShogiList() = default;
+
 			constexpr explicit DobutsuShogiList(
 				const Matrix_Int_& chick_1_,
 				const Matrix_Int_& chick_2_,
@@ -146,7 +148,8 @@ namespace dtl {
 
 			///// コンストラクタ (Constructor) /////
 
-			constexpr RectBaseDobutsuShogi() = default;
+			using RectBase_t::RectBase_t;
+
 			constexpr explicit RectBaseDobutsuShogi(const ::dtl::range::DobutsuShogiList<Matrix_Int_>& draw_value_) noexcept
 				:dobutsuShogiList(draw_value_) {}
 
@@ -163,13 +166,9 @@ namespace dtl {
 				const Matrix_Int_& giraffe_, const Matrix_Int_& elephant_, const Matrix_Int_& lion_) noexcept :
 				dobutsuShogiList(chick_, chick_, hen_, hen_, giraffe_, giraffe_, elephant_, elephant_, lion_, lion_) {}
 
-			constexpr explicit RectBaseDobutsuShogi(const ::dtl::base::MatrixRange& matrix_range_) noexcept
-				:RectBase_t(matrix_range_) {}
 			constexpr explicit RectBaseDobutsuShogi(const ::dtl::base::MatrixRange& matrix_range_, const ::dtl::range::DobutsuShogiList<Matrix_Int_>& draw_value_) noexcept
 				:RectBase_t(matrix_range_),
 				dobutsuShogiList(draw_value_) {}
-			constexpr explicit RectBaseDobutsuShogi(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_) noexcept
-				:RectBase_t(start_x_, start_y_, width_, height_) {}
 			constexpr explicit RectBaseDobutsuShogi(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_, const ::dtl::range::DobutsuShogiList<Matrix_Int_>& draw_value_) noexcept
 				:RectBase_t(start_x_, start_y_, width_, height_),
 				dobutsuShogiList(draw_value_) {}

--- a/include/DTL/Range/RectBaseFractal.hpp
+++ b/include/DTL/Range/RectBaseFractal.hpp
@@ -127,15 +127,15 @@ namespace dtl {
 
 			///// コンストラクタ (Constructor) /////
 
-			constexpr RectBaseFractal() = default;
+			using RectBase_t::RectBase_t;
+
 			constexpr explicit RectBaseFractal(const Matrix_Int_& min_value_) noexcept
 				:min_value(min_value_) {}
 			constexpr explicit RectBaseFractal(const Matrix_Int_& min_value_, const Matrix_Int_& altitude_) noexcept
 				:min_value(min_value_), altitude(altitude_) {}
 			constexpr explicit RectBaseFractal(const Matrix_Int_& min_value_, const Matrix_Int_& altitude_, const Matrix_Int_& add_altitude_) noexcept
 				:min_value(min_value_), altitude(altitude_), add_altitude(add_altitude_) {}
-			constexpr explicit RectBaseFractal(const ::dtl::base::MatrixRange& matrix_range_) noexcept
-				:RectBase_t(matrix_range_) {}
+
 			constexpr explicit RectBaseFractal(const ::dtl::base::MatrixRange& matrix_range_, const Matrix_Int_& min_value_) noexcept
 				:RectBase_t(matrix_range_),
 				min_value(min_value_) {}
@@ -145,8 +145,7 @@ namespace dtl {
 			constexpr explicit RectBaseFractal(const ::dtl::base::MatrixRange& matrix_range_, const Matrix_Int_& min_value_, const Matrix_Int_& altitude_, const Matrix_Int_& add_altitude_) noexcept
 				:RectBase_t(matrix_range_),
 				min_value(min_value_), altitude(altitude_), add_altitude(add_altitude_) {}
-			constexpr explicit RectBaseFractal(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_) noexcept
-				:RectBase_t(start_x_, start_y_, width_, height_) {}
+
 			constexpr explicit RectBaseFractal(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_, const Matrix_Int_& min_value_) noexcept
 				:RectBase_t(start_x_, start_y_, width_, height_),
 				min_value(min_value_) {}

--- a/include/DTL/Range/RectBasePerlin.hpp
+++ b/include/DTL/Range/RectBasePerlin.hpp
@@ -140,7 +140,8 @@ namespace dtl {
 
 			///// コンストラクタ (Constructor) /////
 
-			constexpr RectBasePerlin() = default;
+			using RectBase_t::RectBase_t;
+
 			constexpr explicit RectBasePerlin(const double frequency_) noexcept
 				:frequency(frequency_) {}
 			constexpr explicit RectBasePerlin(const double frequency_, const Index_Size octaves_) noexcept
@@ -148,8 +149,6 @@ namespace dtl {
 			constexpr explicit RectBasePerlin(const double frequency_, const Index_Size octaves_, const Matrix_Int_& max_height_) noexcept
 				:frequency(frequency_), octaves(octaves_), max_height(max_height_) {}
 
-			constexpr explicit RectBasePerlin(const ::dtl::base::MatrixRange& matrix_range_) noexcept
-				:RectBase_t(matrix_range_) {}
 			constexpr explicit RectBasePerlin(const ::dtl::base::MatrixRange& matrix_range_, const double frequency_) noexcept
 				:RectBase_t(matrix_range_),
 				frequency(frequency_) {}
@@ -160,8 +159,6 @@ namespace dtl {
 				:RectBase_t(matrix_range_),
 				frequency(frequency_), octaves(octaves_), max_height(max_height_) {}
 
-			constexpr explicit RectBasePerlin(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_) noexcept
-				:RectBase_t(start_x_, start_y_, width_, height_) {}
 			constexpr explicit RectBasePerlin(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_, const double frequency_) noexcept
 				:RectBase_t(start_x_, start_y_, width_, height_),
 				frequency(frequency_) {}

--- a/include/DTL/Range/RectBaseShogi.hpp
+++ b/include/DTL/Range/RectBaseShogi.hpp
@@ -54,6 +54,8 @@ namespace dtl {
 			Matrix_Int_ osho{};
 			Matrix_Int_ gyokusho{};
 
+			constexpr ShogiList() = default;
+
 			constexpr explicit ShogiList(
 			const Matrix_Int_& fuhyo_1_, 
 			const Matrix_Int_& fuhyo_2_,
@@ -227,7 +229,8 @@ namespace dtl {
 
 			///// コンストラクタ (Constructor) /////
 
-			constexpr RectBaseShogi() = default;
+			using RectBase_t::RectBase_t;
+
 			constexpr explicit RectBaseShogi(const ::dtl::range::ShogiList<Matrix_Int_>& draw_value_) noexcept
 				:shogiList(draw_value_) {}
 
@@ -260,13 +263,9 @@ namespace dtl {
 				shogiList(fuhyo_, fuhyo_, tokin_, tokin_, kyosha_, kyosha_, narikyo_, narikyo_, keima_, keima_, narikei_, narikei_, ginsho_, ginsho_,
 					narigin_, narigin_, hisha_, hisha_, ryuo_, ryuo_, kakugyo_, kakugyo_, ryuma_, ryuma_, kinsho_, kinsho_, osho_, osho_) {}
 
-			constexpr explicit RectBaseShogi(const ::dtl::base::MatrixRange& matrix_range_) noexcept
-				:RectBase_t(matrix_range_) {}
 			constexpr explicit RectBaseShogi(const ::dtl::base::MatrixRange& matrix_range_, const ::dtl::range::ShogiList<Matrix_Int_>& draw_value_) noexcept
 				:RectBase_t(matrix_range_),
 				shogiList(draw_value_) {}
-			constexpr explicit RectBaseShogi(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_) noexcept
-				:RectBase_t(start_x_, start_y_, width_, height_) {}
 			constexpr explicit RectBaseShogi(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_, const ::dtl::range::ShogiList<Matrix_Int_>& draw_value_) noexcept
 				:RectBase_t(start_x_, start_y_, width_, height_),
 				shogiList(draw_value_) {}

--- a/include/DTL/Range/RectBaseWithLoopNum.hpp
+++ b/include/DTL/Range/RectBaseWithLoopNum.hpp
@@ -93,16 +93,13 @@ namespace dtl {
 
 			///// コンストラクタ (Constructor) /////
 
-			constexpr RectBaseWithLoopNum() = default;
+			using RectBase_t::RectBase_t;
+
 			constexpr explicit RectBaseWithLoopNum(const Index_Size& loop_num_) noexcept
 				:loop_num(loop_num_) {}
-			constexpr explicit RectBaseWithLoopNum(const ::dtl::base::MatrixRange& matrix_range_) noexcept
-				:RectBase_t(matrix_range_) {}
 			constexpr explicit RectBaseWithLoopNum(const ::dtl::base::MatrixRange& matrix_range_, const Index_Size& loop_num_) noexcept
 				:RectBase_t(matrix_range_),
 				loop_num(loop_num_) {}
-			constexpr explicit RectBaseWithLoopNum(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_) noexcept
-				:RectBase_t(start_x_, start_y_, width_, height_) {}
 			constexpr explicit RectBaseWithLoopNum(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_, const Index_Size& loop_num_) noexcept
 				:RectBase_t(start_x_, start_y_, width_, height_),
 				loop_num(loop_num_) {}

--- a/include/DTL/Range/RectBaseWithValue.hpp
+++ b/include/DTL/Range/RectBaseWithValue.hpp
@@ -94,16 +94,13 @@ namespace dtl {
 
 			///// コンストラクタ (Constructor) /////
 
-			constexpr RectBaseWithValue() = default;
+			using RectBase_t::RectBase_t;
+
 			constexpr explicit RectBaseWithValue(const Matrix_Int_ & draw_value_) noexcept
 				:draw_value(draw_value_) {}
-			constexpr explicit RectBaseWithValue(const ::dtl::base::MatrixRange & matrix_range_) noexcept
-				:RectBase_t(matrix_range_) {}
 			constexpr explicit RectBaseWithValue(const ::dtl::base::MatrixRange & matrix_range_, const Matrix_Int_ & draw_value_) noexcept
 				:RectBase_t(matrix_range_),
 				draw_value(draw_value_) {}
-			constexpr explicit RectBaseWithValue(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_) noexcept
-				:RectBase_t(start_x_, start_y_, width_, height_) {}
 			constexpr explicit RectBaseWithValue(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_, const Matrix_Int_ & draw_value_) noexcept
 				:RectBase_t(start_x_, start_y_, width_, height_),
 				draw_value(draw_value_) {}


### PR DESCRIPTION
BasicRect のコンストラクタは、全ての派生クラスでそのままの引数で使用され
ていたため、コンストラクタを public にして派生クラスでは継承コンストラク
タを使用するように変更しました。