### PR TITLE
[Fix] 継承コンストラクタに絡むバグを修正しました

### DIFF
--- a/include/DTL/Range/RectBaseDobutsuShogi.hpp
+++ b/include/DTL/Range/RectBaseDobutsuShogi.hpp
@@ -362,7 +362,11 @@ namespace dtl {
 
 			///// コンストラクタ (Constructor) /////
 
-			using RectBase_t::RectBase_t;
+			RectBaseDobutsuShogi() = default;
+			constexpr explicit RectBaseDobutsuShogi(const ::dtl::base::MatrixRange& matrix_range_) noexcept
+				:RectBase_t(matrix_range_) {}
+			constexpr explicit RectBaseDobutsuShogi(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_) noexcept
+				:RectBase_t(start_x_, start_y_, width_, height_) {}
 
 			constexpr explicit RectBaseDobutsuShogi(const ::dtl::range::DobutsuShogiList<Matrix_Int_>& draw_value_) noexcept
 				:dobutsuShogiList(draw_value_) {}

--- a/include/DTL/Range/RectBaseFractal.hpp
+++ b/include/DTL/Range/RectBaseFractal.hpp
@@ -127,7 +127,11 @@ namespace dtl {
 
 			///// コンストラクタ (Constructor) /////
 
-			using RectBase_t::RectBase_t;
+			RectBaseFractal() = default;
+			constexpr explicit RectBaseFractal(const ::dtl::base::MatrixRange& matrix_range_) noexcept
+				:RectBase_t(matrix_range_) {}
+			constexpr explicit RectBaseFractal(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_) noexcept
+				:RectBase_t(start_x_, start_y_, width_, height_) {}
 
 			constexpr explicit RectBaseFractal(const Matrix_Int_& min_value_) noexcept
 				:min_value(min_value_) {}

--- a/include/DTL/Range/RectBasePerlin.hpp
+++ b/include/DTL/Range/RectBasePerlin.hpp
@@ -158,7 +158,11 @@ namespace dtl {
 
 			///// コンストラクタ (Constructor) /////
 
-			using RectBase_t::RectBase_t;
+			RectBasePerlin() = default;
+			constexpr explicit RectBasePerlin(const ::dtl::base::MatrixRange& matrix_range_) noexcept
+				:RectBase_t(matrix_range_) {}
+			constexpr explicit RectBasePerlin(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_) noexcept
+				:RectBase_t(start_x_, start_y_, width_, height_) {}
 
 			constexpr explicit RectBasePerlin(const double frequency_) noexcept
 				:frequency(frequency_) {}

--- a/include/DTL/Range/RectBaseShogi.hpp
+++ b/include/DTL/Range/RectBaseShogi.hpp
@@ -342,7 +342,11 @@ namespace dtl {
 
 			///// コンストラクタ (Constructor) /////
 
-			using RectBase_t::RectBase_t;
+			RectBaseShogi() = default;
+			constexpr explicit RectBaseShogi(const ::dtl::base::MatrixRange& matrix_range_) noexcept
+				:RectBase_t(matrix_range_) {}
+			constexpr explicit RectBaseShogi(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_) noexcept
+				:RectBase_t(start_x_, start_y_, width_, height_) {}
 
 			constexpr explicit RectBaseShogi(const ::dtl::range::ShogiList<Matrix_Int_>& draw_value_) noexcept
 				:shogiList(draw_value_) {}

--- a/include/DTL/Range/RectBaseWithLoopNum.hpp
+++ b/include/DTL/Range/RectBaseWithLoopNum.hpp
@@ -93,7 +93,11 @@ namespace dtl {
 
 			///// コンストラクタ (Constructor) /////
 
-			using RectBase_t::RectBase_t;
+			RectBaseWithLoopNum() = default;
+			constexpr explicit RectBaseWithLoopNum(const ::dtl::base::MatrixRange& matrix_range_) noexcept
+				:RectBase_t(matrix_range_) {}
+			constexpr explicit RectBaseWithLoopNum(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_) noexcept
+				:RectBase_t(start_x_, start_y_, width_, height_) {}
 
 			constexpr explicit RectBaseWithLoopNum(const Index_Size& loop_num_) noexcept
 				:loop_num(loop_num_) {}

--- a/include/DTL/Range/RectBaseWithValue.hpp
+++ b/include/DTL/Range/RectBaseWithValue.hpp
@@ -121,7 +121,11 @@ namespace dtl {
 
 			///// コンストラクタ (Constructor) /////
 
-			using RectBase_t::RectBase_t;
+			RectBaseWithValue() = default;
+			constexpr explicit RectBaseWithValue(const ::dtl::base::MatrixRange& matrix_range_) noexcept
+				:RectBase_t(matrix_range_)  {}
+			constexpr explicit RectBaseWithValue(const Index_Size start_x_, const Index_Size start_y_, const Index_Size width_, const Index_Size height_) noexcept
+				:RectBase_t(start_x_, start_y_, width_, height_) {}
 
 			constexpr explicit RectBaseWithValue(const Matrix_Int_ & draw_value_) noexcept
 				:draw_value(draw_value_) {}


### PR DESCRIPTION
GCC 7 より前、および、Clang 3.9 より前までは継承コンストラクタと派生クラ
ス独自のコンストラクタを同時に使用することができなかったため、両方ともあ
るクラスの場合は明示的に基底クラスのコンストラクタを呼び出すように修正し
ました。