### PR TITLE
🔀 [Change]: Revert "circleci ruby -> python"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.8.1
+      - image: circleci/ruby:2.4.1
     steps:
       - checkout
       - run: ls && cd Sample/DTL/Shape/ && ls && gcc --version && g++ All.cpp -Wall -Wextra -O2 -march=native -I../../../include/ -std=c++11 && g++ All.cpp -Wall -Wextra -O2 -march=native -I../../../include/ -std=c++14


### PR DESCRIPTION
Reverts Kasugaccho/DungeonTemplateLibrary#39