### PR TITLE
Remove unused loopval

### DIFF
--- a/include/DTL/Utility/VoronoiDiagram.hpp
+++ b/include/DTL/Utility/VoronoiDiagram.hpp
@@ -59,7 +59,7 @@ namespace dtl {
 			template<typename Function_>
 			DTL_VERSIONING_CPP14_CONSTEXPR
 				void createPoint(UniquePair_& point_, UniqueInt_& color_, const ::dtl::type::ssize w_, const ::dtl::type::ssize h_, Function_&& function_) const noexcept {
-				for (::dtl::type::size i{}, array_num{}; i < this->draw_value; ++i, ++array_num) {
+				for (::dtl::type::size array_num{}; array_num < this->draw_value; ++array_num) {
 					point_[array_num] = Point_Pair_(DTL_RANDOM_ENGINE.get<::dtl::type::ssize>(w_), DTL_RANDOM_ENGINE.get<::dtl::type::ssize>(h_));
 					function_(point_[array_num], color_[array_num], static_cast<::dtl::type::ssize>(start_x), static_cast<::dtl::type::ssize>(start_x), w_, h_);
 				}


### PR DESCRIPTION
VoronoiDiagram.hpp の使用していないループ変数を削除しました。